### PR TITLE
Enable/disable BatteryLevelReceiver

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
 		android:theme="@style/AppTheme">
 		<receiver
 			android:name=".receiver.BatteryLevelReceiver"
-			android:enabled="true"
+			android:enabled="false"
 			android:exported="false"
 			android:label="LowBatteryMonitor">
 			<intent-filter>

--- a/app/src/main/java/de/markusfisch/android/shadereditor/service/ShaderWallpaperService.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/service/ShaderWallpaperService.java
@@ -8,6 +8,7 @@ import android.database.Cursor;
 import android.opengl.GLSurfaceView;
 import android.os.Handler;
 import android.service.wallpaper.WallpaperService;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 
@@ -24,6 +25,7 @@ public class ShaderWallpaperService extends WallpaperService {
 
 	@Override
 	public void onCreate() {
+		Log.d("ShaderWallpaperService", "onCreate: ");
 		super.onCreate();
 		PackageManager pm  = getPackageManager();
 		ComponentName componentName = new ComponentName(ShaderWallpaperService.this, BatteryLevelReceiver.class);
@@ -51,6 +53,16 @@ public class ShaderWallpaperService extends WallpaperService {
 		return (engine = new ShaderWallpaperEngine());
 	}
 
+	@Override
+	public void onDestroy()
+	{
+		Log.d("ShaderWallpaperService", "onDestroy: ");
+		super.onDestroy();
+		PackageManager pm  = getPackageManager();
+		ComponentName componentName = new ComponentName(ShaderWallpaperService.this, BatteryLevelReceiver.class);
+		pm.setComponentEnabledSetting(componentName,PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+	}
+
 	private class ShaderWallpaperEngine
 			extends Engine
 			implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -76,12 +88,9 @@ public class ShaderWallpaperService extends WallpaperService {
 
 		@Override
 		public void onDestroy() {
-			super.onDestroy();
+            super.onDestroy();
 			view.destroy();
 			view = null;
-			PackageManager pm  = getPackageManager();
-			ComponentName componentName = new ComponentName(ShaderWallpaperService.this, BatteryLevelReceiver.class);
-			pm.setComponentEnabledSetting(componentName,PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
 		}
 
 		@Override

--- a/app/src/main/java/de/markusfisch/android/shadereditor/service/ShaderWallpaperService.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/service/ShaderWallpaperService.java
@@ -1,12 +1,9 @@
 package de.markusfisch.android.shadereditor.service;
 
-import de.markusfisch.android.shadereditor.app.ShaderEditorApplication;
-import de.markusfisch.android.shadereditor.database.DataSource;
-import de.markusfisch.android.shadereditor.preference.Preferences;
-import de.markusfisch.android.shadereditor.widget.ShaderView;
-
+import android.content.ComponentName;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.opengl.GLSurfaceView;
 import android.os.Handler;
@@ -14,10 +11,24 @@ import android.service.wallpaper.WallpaperService;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 
+import de.markusfisch.android.shadereditor.app.ShaderEditorApplication;
+import de.markusfisch.android.shadereditor.database.DataSource;
+import de.markusfisch.android.shadereditor.preference.Preferences;
+import de.markusfisch.android.shadereditor.receiver.BatteryLevelReceiver;
+import de.markusfisch.android.shadereditor.widget.ShaderView;
+
 public class ShaderWallpaperService extends WallpaperService {
 	public static final String RENDER_MODE = "render_mode";
 
 	private ShaderWallpaperEngine engine;
+
+	@Override
+	public void onCreate() {
+		super.onCreate();
+		PackageManager pm  = getPackageManager();
+		ComponentName componentName = new ComponentName(ShaderWallpaperService.this, BatteryLevelReceiver.class);
+		pm.setComponentEnabledSetting(componentName,PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP);
+	}
 
 	@Override
 	public int onStartCommand(
@@ -68,7 +79,9 @@ public class ShaderWallpaperService extends WallpaperService {
 			super.onDestroy();
 			view.destroy();
 			view = null;
-			stopSelf();
+			PackageManager pm  = getPackageManager();
+			ComponentName componentName = new ComponentName(ShaderWallpaperService.this, BatteryLevelReceiver.class);
+			pm.setComponentEnabledSetting(componentName,PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
 		}
 
 		@Override


### PR DESCRIPTION
ShaderWallpaperService onCreate gets called when you set a wallpaper, onDestroy gets called when you set a wallpaper (edit: from a different app) . So that works fine.
BatteryLevelReceiver should only call the service if it's being used.