### PR TITLE
Add simple import and export functionality for shaders

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
 	<uses-permission
 		android:name="android.permission.READ_EXTERNAL_STORAGE"
 		android:maxSdkVersion="19"/>
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-feature android:glEsVersion="0x00020000"/>
 	<uses-feature android:name="android.software.live_wallpaper"/>
 	<application

--- a/app/src/main/java/de/markusfisch/android/shadereditor/database/Database.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/database/Database.java
@@ -268,6 +268,14 @@ public class Database {
 		return insertShader(db, shader, null, thumbnail, quality);
 	}
 
+	public long insertShader(
+			Context context,
+			String shader,
+			String name) {
+		return insertShader(db, shader, name,
+				loadBitmapResource(context, R.drawable.thumbnail_new_shader), 1f);
+	}
+
 	public long insertNewShader(Context context) {
 		return insertShaderFromResource(
 				context,

--- a/app/src/main/java/de/markusfisch/android/shadereditor/database/ImportExport.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/database/ImportExport.java
@@ -1,0 +1,168 @@
+package de.markusfisch.android.shadereditor.database;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.database.Cursor;
+import android.os.Environment;
+import android.widget.Toast;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import de.markusfisch.android.shadereditor.R;
+import de.markusfisch.android.shadereditor.app.ShaderEditorApp;
+
+public class ImportExport {
+	private static final String IMPORT_EXPORT_DIRECTORY = "ShaderEditor";
+	private static final String SHADER_FILE_EXTENSION = ".glsl";
+	private static final String ILLEGAL_CHARACTER_REPLACEMENT = "_";
+
+	public static void importFromDirectory(Context context) {
+		try {
+			File importDirectory = getImportExportDirectory(context, false);
+			File[] files = importDirectory.listFiles();
+
+			int successCount = 0;
+			int failCount = 0;
+
+			for (File file : files) {
+				if (file.getName().toLowerCase().endsWith(SHADER_FILE_EXTENSION)) {
+					try {
+						String shaderName = file.getName();
+						shaderName = shaderName.substring(0, shaderName.length()
+								- SHADER_FILE_EXTENSION.length());
+						String fragmentShader = readFile(file);
+						ShaderEditorApp.db.insertShader(context, fragmentShader, shaderName);
+						successCount++;
+					} catch (IOException e) {
+						failCount++;
+					}
+				}
+			}
+
+			if (successCount > 0) {
+				Resources res = context.getResources();
+				String str;
+				if (failCount > 0) {
+					str = res.getQuantityString(R.plurals.n_shaders_successfully_imported_m_failed,
+							successCount, successCount, failCount);
+				} else {
+					str = res.getQuantityString(R.plurals.n_shaders_successfully_imported,
+							successCount, successCount);
+				}
+				Toast.makeText(context, str, Toast.LENGTH_LONG).show();
+			} else {
+				Toast.makeText(context, R.string.no_shaders_found, Toast.LENGTH_LONG).show();
+			}
+		} catch (IOException e) {
+			Toast.makeText(context, context.getString(R.string.import_failed, e.getMessage()),
+					Toast.LENGTH_LONG).show();
+		}
+	}
+
+	public static void exportToDirectory(Context context) {
+		try {
+			File exportDirectory = getImportExportDirectory(context, true);
+
+			Cursor shadersCursor = ShaderEditorApp.db.getShaders();
+			if (Database.closeIfEmpty(shadersCursor)) {
+				throw new IOException(context.getString(R.string.no_shaders_found));
+			}
+
+			int successCount = 0;
+			int failCount = 0;
+
+			do {
+				long shaderId = shadersCursor.getLong(shadersCursor.getColumnIndex(
+						Database.SHADERS_ID));
+				Cursor shaderCursor = ShaderEditorApp.db.getShader(shaderId);
+				if (Database.closeIfEmpty(shaderCursor)) {
+					continue;
+				}
+				String shaderName = shaderCursor.getString(shaderCursor.getColumnIndex(
+						Database.SHADERS_NAME));
+				if (shaderName == null) {
+					shaderName = shaderCursor.getString(shaderCursor.getColumnIndex(
+							Database.SHADERS_MODIFIED));
+				}
+				String fragmentShader = shaderCursor.getString(shaderCursor.getColumnIndex(
+						Database.SHADERS_FRAGMENT_SHADER));
+				shaderCursor.close();
+
+				try {
+					writeShaderToDirectory(exportDirectory, shaderName, fragmentShader);
+					successCount++;
+				} catch (IOException e) {
+					failCount++;
+				}
+			} while (shadersCursor.moveToNext());
+			shadersCursor.close();
+
+			if (successCount == 0) {
+				throw new IOException(context.getString(R.string.no_shaders_could_be_written));
+			} else {
+				Resources res = context.getResources();
+				String str;
+				if (failCount > 0) {
+					str = res.getQuantityString(R.plurals.n_shaders_successfully_exported_m_failed,
+							successCount, successCount, failCount);
+				} else {
+					str = res.getQuantityString(R.plurals.n_shaders_successfully_exported,
+							successCount, successCount);
+				}
+				Toast.makeText(context, str, Toast.LENGTH_LONG).show();
+			}
+		} catch (IOException e) {
+			Toast.makeText(context, context.getString(R.string.export_failed, e.getMessage()),
+					Toast.LENGTH_LONG).show();
+		}
+	}
+
+	private static void writeShaderToDirectory(File directory, String shaderName,
+											   String fragmentShader) throws IOException {
+		String filename = shaderName.replaceAll("[^a-zA-Z0-9 \\-_,()]",
+				ILLEGAL_CHARACTER_REPLACEMENT);
+		File shaderFile = new File(directory, filename + SHADER_FILE_EXTENSION);
+		int fileCounter = 1;
+		while (shaderFile.exists()) {
+			shaderFile = new File(directory, filename + " (" + Integer.toString(fileCounter++)
+					+ ")" + SHADER_FILE_EXTENSION);
+		}
+
+		FileOutputStream outputStream;
+		outputStream = new FileOutputStream(shaderFile);
+		outputStream.write(fragmentShader.getBytes("UTF-8"));
+		outputStream.close();
+	}
+
+	private static File getImportExportDirectory(Context context, boolean create) throws IOException {
+		File downloadsDirectory =
+				Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+		File file = new File(downloadsDirectory, IMPORT_EXPORT_DIRECTORY);
+
+		if (create) {
+			//noinspection ResultOfMethodCallIgnored
+			file.mkdirs();
+		}
+
+		if (!file.isDirectory()) {
+			throw new IOException(context.getString(R.string.path_is_no_directory,
+					downloadsDirectory));
+		}
+
+		return file;
+	}
+
+	private static String readFile(File file) throws IOException {
+		FileInputStream fis = new FileInputStream(file);
+		StringBuilder content = new StringBuilder();
+		byte[] buffer = new byte[1024];
+		int n;
+		while ((n = fis.read(buffer)) != -1) {
+			content.append(new String(buffer, 0, n));
+		}
+		return content.toString();
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/preference/Preferences.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/preference/Preferences.java
@@ -24,6 +24,8 @@ public class Preferences {
 	public static final String DEFAULT_NEW_SHADER = "default_new_shader";
 	public static final String DISABLE_HIGHLIGHTING = "disable_highlighting";
 	public static final String AUTO_SAVE = "auto_save";
+	public static final String IMPORT_FROM_DIRECTORY = "import_from_directory";
+	public static final String EXPORT_TO_DIRECTORY = "export_to_directory";
 
 	private static final int RUN_AUTO = 1;
 	private static final int RUN_MANUALLY = 2;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,11 @@
 	<string name="auto_save">Auto save</string>
 	<string name="auto_save_summary">Save shader automatically</string>
 	<string name="default_new_shader">Default new shader</string>
+	<string name="import_export">Import / Export</string>
+	<string name="import_shaders">Import shaders</string>
+	<string name="import_from_directory">Import all *.glsl files from Download/ShaderEditor</string>
+	<string name="export_shaders">Export shaders</string>
+	<string name="export_to_directory">Export all shaders to Download/ShaderEditor</string>
 
 	<!-- Preferences -->
 	<string name="run_auto">Auto run on change</string>
@@ -183,4 +188,29 @@
 
 	<!-- Database -->
 	<string name="default_shader">Default</string>
+
+	<!-- ImportExport -->
+	<string name="write_access_required">Write access to external storage is required for export to work.</string>
+	<string name="read_access_required">Read access to external storage is required for import to work.</string>
+	<plurals name="n_shaders_successfully_exported">
+		<item quantity="one">%1$d shader successfully exported</item>
+		<item quantity="other">%1$d shaders successfully exported</item>
+	</plurals>
+	<plurals name="n_shaders_successfully_exported_m_failed">
+		<item quantity="one">%1$d shader successfully exported, %2$d failed</item>
+		<item quantity="other">%1$d shaders successfully exported, %2$d failed</item>
+	</plurals>
+	<string name="export_failed">Export failed: %1$s</string>
+	<plurals name="n_shaders_successfully_imported">
+		<item quantity="one">%1$d shader successfully imported</item>
+		<item quantity="other">%1$d shaders successfully imported</item>
+	</plurals>
+	<plurals name="n_shaders_successfully_imported_m_failed">
+		<item quantity="one">%1$d shader successfully imported, %2$d failed</item>
+		<item quantity="other">%1$d shaders successfully imported, %2$d failed</item>
+	</plurals>
+	<string name="import_failed">Import failed: %1$s</string>
+	<string name="no_shaders_found">No shaders found</string>
+	<string name="no_shaders_could_be_written">No shaders could be written to directory</string>
+	<string name="path_is_no_directory">Path %1$s is not a directory</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -83,4 +83,15 @@
 			android:entryValues="@array/sensor_delay_values"
 			android:defaultValue="Normal"/>
 	</PreferenceCategory>
+	<PreferenceCategory
+		android:title="@string/import_export">
+		<Preference
+			android:key="import_from_directory"
+			android:title="@string/import_shaders"
+			android:summary="@string/import_from_directory"/>
+		<Preference
+			android:key="export_to_directory"
+			android:title="@string/export_shaders"
+			android:summary="@string/export_to_directory"/>
+	</PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Export shaders to Download/ShaderEditor with shader name as filename
Avoid accidental overwriting when exporting by choosing unique filename
- an increasing number is appended until the filename is not taken
Import *.glsl files from Download/ShaderEditor
Avoid accidental overwriting when importing
- Always insert, do not overwrite when importing
Quality and thumbnail are not exported / imported

Fixes #5
Fixes #84