### PR TITLE
remove bad "android:minSdkVersion"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,8 +7,7 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 	<!-- Camera textures are only supported from API > 14 -->
-	<uses-permission android:name="android.permission.CAMERA"
-		android:minSdkVersion="15"/>
+	<uses-permission android:name="android.permission.CAMERA"/>
 	<!-- Required to import textures on API < 19 from gallery apps
 		that do not use grantUriPermission(); later API's will not
 		see that permission -->


### PR DESCRIPTION
If you look at the docs you can see that `<uses-permission>` does not support "minSdkVersion", only "maxSdkVersion":
https://developer.android.com/guide/topics/manifest/uses-permission-element

For more info:
https://gitlab.com/fdroid/fdroidclient/issues/1702