### PR TITLE
Add media volume uniform

### DIFF
--- a/app/src/main/java/de/markusfisch/android/shadereditor/adapter/PresetUniformAdapter.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/adapter/PresetUniformAdapter.java
@@ -185,6 +185,10 @@ public class PresetUniformAdapter extends BaseAdapter {
 						ShaderRenderer.UNIFORM_TIME,
 						context.getString(R.string.time_in_seconds_since_load)),
 				new Uniform(
+						"float",
+						ShaderRenderer.UNIFORM_MEDIA_VOLUME,
+						context.getString(R.string.media_volume_level)),
+				new Uniform(
 						"vec2",
 						ShaderRenderer.UNIFORM_TOUCH,
 						context.getString(R.string.touch_position_in_pixels)),

--- a/app/src/main/java/de/markusfisch/android/shadereditor/opengl/ShaderRenderer.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/opengl/ShaderRenderer.java
@@ -10,6 +10,7 @@ import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.hardware.Camera;
 import android.hardware.SensorManager;
+import android.media.AudioManager;
 import android.opengl.GLES11Ext;
 import android.opengl.GLES20;
 import android.opengl.GLSurfaceView;
@@ -88,6 +89,7 @@ public class ShaderRenderer implements GLSurfaceView.Renderer {
 	public static final String UNIFORM_START_RANDOM = "startRandom";
 	public static final String UNIFORM_SUB_SECOND = "subsecond";
 	public static final String UNIFORM_TIME = "time";
+	public static final String UNIFORM_MEDIA_VOLUME = "mediaVolume";
 	public static final String UNIFORM_TOUCH = "touch";
 	public static final String UNIFORM_TOUCH_START = "touchStart";
 
@@ -271,6 +273,7 @@ public class ShaderRenderer implements GLSurfaceView.Renderer {
 	private int backBufferLoc;
 	private int cameraOrientationLoc;
 	private int cameraAddentLoc;
+	private int mediaVolumeLoc;
 	private int nightMode;
 	private int numberOfTextures;
 	private int pointerCount;
@@ -521,6 +524,9 @@ public class ShaderRenderer implements GLSurfaceView.Renderer {
 		}
 		if (startRandomLoc > -1) {
 			GLES20.glUniform1f(startRandomLoc, startRandom);
+		}
+		if (mediaVolumeLoc > -1) {
+			GLES20.glUniform1f(mediaVolumeLoc, getMediaVolumeLevel(context));
 		}
 
 		if (fb[0] == 0) {
@@ -799,6 +805,8 @@ public class ShaderRenderer implements GLSurfaceView.Renderer {
 				program, UNIFORM_CAMERA_ORIENTATION);
 		cameraAddentLoc = GLES20.glGetUniformLocation(
 				program, UNIFORM_CAMERA_ADDENT);
+		mediaVolumeLoc = GLES20.glGetUniformLocation(
+				program, UNIFORM_MEDIA_VOLUME);
 
 		for (int i = numberOfTextures; i-- > 0; ) {
 			textureLocs[i] = GLES20.glGetUniformLocation(
@@ -1419,6 +1427,15 @@ public class ShaderRenderer implements GLSurfaceView.Renderer {
 			case Surface.ROTATION_270:
 				return 270;
 		}
+	}
+	private static float getMediaVolumeLevel(Context context) {
+		AudioManager audio = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+		float maxVolume = audio.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+		float currVolume = audio.getStreamVolume(AudioManager.STREAM_MUSIC);
+		if (maxVolume <= 0 || currVolume < 0) {
+			return 0;
+		}
+		return currVolume / maxVolume;
 	}
 
 	private static class TextureBinder {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,7 @@
 	<string name="date_time">Year, month, day and time in seconds</string>
 	<string name="daytime">Hour, minute and seconds</string>
 	<string name="start_random">Random value from 0.0 to 1.0, initialized at load</string>
+	<string name="media_volume_level">Media volume level from 0.0 to 1.0</string>
 
 	<!-- UniformSampler2dPageFragment -->
 	<string name="texture_preview">Texture preview</string>


### PR DESCRIPTION
Hi I've been using your app for a while now and its been a lot of fun to play around with shaders as my wallpapers. But recently I wanted to access the devices current media volume for one of my shaders. Then I noticed that adding a volume uniform might be a fun idea as a first commit on a public repo. So I'm very open for any feedback.