### PR TITLE
feat: Add horizontal scrolling to the editor

### DIFF
--- a/app/src/main/res/layout/fragment_editor.xml
+++ b/app/src/main/res/layout/fragment_editor.xml
@@ -2,34 +2,33 @@
 	contents. If we make EditText scrollable, contents will be cut off
 	at the specified padding but before the visible border. -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/scroll_view"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/background_editor"
-    android:fillViewport="true"
-    tools:ignore="Overdraw">
-    <!-- Hardcode gravity to left because GLSL source code is always
-        aligned to the left. -->
-    <HorizontalScrollView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fillViewport="true"
-        android:scrollbars="none">
-
-        <de.markusfisch.android.shadereditor.widget.ShaderEditor
-            android:id="@+id/editor"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:background="@android:color/transparent"
-            android:ellipsize="end"
-            android:gravity="left|top"
-            android:imeOptions="flagNoExtractUi"
-            android:inputType="textMultiLine|textNoSuggestions"
-            android:padding="8dp"
-            android:textColor="@color/editor_text"
-            android:textSize="12sp"
-            android:typeface="monospace"
-            tools:ignore="RtlHardcoded" />
-    </HorizontalScrollView>
+	xmlns:tools="http://schemas.android.com/tools"
+	android:id="@+id/scroll_view"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:background="@color/background_editor"
+	android:fillViewport="true"
+	tools:ignore="Overdraw">
+	<!-- Hardcode gravity to left because GLSL source code is always
+		aligned to the left. -->
+	<HorizontalScrollView
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:fillViewport="true"
+		android:scrollbars="none">
+		<de.markusfisch.android.shadereditor.widget.ShaderEditor
+			android:id="@+id/editor"
+			android:layout_width="wrap_content"
+			android:layout_height="match_parent"
+			android:background="@android:color/transparent"
+			android:ellipsize="end"
+			android:gravity="left|top"
+			android:imeOptions="flagNoExtractUi"
+			android:inputType="textMultiLine|textNoSuggestions"
+			android:padding="8dp"
+			android:textColor="@color/editor_text"
+			android:textSize="12sp"
+			android:typeface="monospace"
+			tools:ignore="RtlHardcoded" />
+	</HorizontalScrollView>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_editor.xml
+++ b/app/src/main/res/layout/fragment_editor.xml
@@ -1,28 +1,35 @@
 <!-- Use a ScrollView around EditText to have a padding around the text
 	contents. If we make EditText scrollable, contents will be cut off
 	at the specified padding but before the visible border. -->
-<ScrollView
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:tools="http://schemas.android.com/tools"
-	tools:ignore="Overdraw"
-	android:id="@+id/scroll_view"
-	android:layout_width="match_parent"
-	android:layout_height="match_parent"
-	android:background="@color/background_editor">
-	<!-- Hardcode gravity to left because GLSL source code is always
-		aligned to the left. -->
-	<de.markusfisch.android.shadereditor.widget.ShaderEditor
-		tools:ignore="RtlHardcoded"
-		android:id="@+id/editor"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:padding="8dp"
-		android:gravity="left|top"
-		android:typeface="monospace"
-		android:textSize="12sp"
-		android:textColor="@color/editor_text"
-		android:ellipsize="end"
-		android:imeOptions="flagNoExtractUi"
-		android:inputType="textMultiLine|textNoSuggestions"
-		android:background="@android:color/transparent"/>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scroll_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_editor"
+    android:fillViewport="true"
+    tools:ignore="Overdraw">
+    <!-- Hardcode gravity to left because GLSL source code is always
+        aligned to the left. -->
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true"
+        android:scrollbars="none">
+
+        <de.markusfisch.android.shadereditor.widget.ShaderEditor
+            android:id="@+id/editor"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@android:color/transparent"
+            android:ellipsize="end"
+            android:gravity="left|top"
+            android:imeOptions="flagNoExtractUi"
+            android:inputType="textMultiLine|textNoSuggestions"
+            android:padding="8dp"
+            android:textColor="@color/editor_text"
+            android:textSize="12sp"
+            android:typeface="monospace"
+            tools:ignore="RtlHardcoded" />
+    </HorizontalScrollView>
 </ScrollView>


### PR DESCRIPTION
This adds a quality of live feature.

Without this feature, you have to move your cursor to the very end of the line. Often times there only is one long line and if you move your finger to far vertically from this line when trying to move the cursor, the scroll snaps back to the cursor position (which often times is an empty line).

Fixes #96 