### PR TITLE
Add notification uniforms

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,6 +63,14 @@
 				android:name="android.service.wallpaper"
 				android:resource="@xml/wallpaper"/>
 		</service>
+		<service android:name="de.markusfisch.android.shadereditor.service.NotificationService"
+			android:exported="false"
+			android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+			<intent-filter>
+				<action android:name="android.service.notification.NotificationListenerService"/>
+			</intent-filter>
+		</service>
+
 		<activity
 			android:name=".activity.SplashActivity"
 			android:theme="@style/SplashTheme"

--- a/app/src/main/java/de/markusfisch/android/shadereditor/adapter/PresetUniformAdapter.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/adapter/PresetUniformAdapter.java
@@ -114,6 +114,11 @@ public class PresetUniformAdapter extends BaseAdapter implements Filterable {
 						ShaderRenderer.UNIFORM_GYROSCOPE,
 						context.getString(R.string.gyroscope)),
 				new Uniform(
+					"float",
+					ShaderRenderer.UNIFORM_LAST_NOTIFICATION_TIME,
+					context.getString(R.string.last_notification_time)
+				),
+				new Uniform(
 						"float",
 						ShaderRenderer.UNIFORM_INCLINATION,
 						context.getString(R.string.device_inclination)),
@@ -137,6 +142,11 @@ public class PresetUniformAdapter extends BaseAdapter implements Filterable {
 						"int",
 						ShaderRenderer.UNIFORM_NIGHT_MODE,
 						context.getString(R.string.night_mode)),
+				new Uniform(
+					"int",
+					ShaderRenderer.UNIFORM_NOTIFICATION_COUNT,
+					context.getString(R.string.notification_count)
+				),
 				new Uniform(
 						"vec2",
 						ShaderRenderer.UNIFORM_OFFSET,

--- a/app/src/main/java/de/markusfisch/android/shadereditor/service/NotificationService.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/service/NotificationService.java
@@ -1,0 +1,102 @@
+package de.markusfisch.android.shadereditor.service;
+
+import android.app.AlertDialog;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.provider.Settings;
+import android.service.notification.NotificationListenerService;
+import android.service.notification.StatusBarNotification;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import de.markusfisch.android.shadereditor.R;
+
+@RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
+public class NotificationService extends NotificationListenerService {
+	private static int counter = 0;
+	private static Long lastNotificationTime = null;
+
+	@Override
+	public synchronized void onNotificationPosted(StatusBarNotification sbn) {
+		counter = getActiveNotifications().length;
+		lastNotificationTime = sbn.getPostTime();
+	}
+
+	@Override
+	public synchronized void onNotificationRemoved(StatusBarNotification sbn) {
+		counter = getActiveNotifications().length;
+	}
+
+	@Override
+	public void onListenerConnected() {
+		invalidate();
+	}
+
+	@Override
+	public void onListenerDisconnected() {
+		counter = 0;
+		lastNotificationTime = null;
+	}
+
+	private void invalidate() {
+		requirePermissions(this);
+		StatusBarNotification[] notifications = getActiveNotifications();
+		Long lastTime;
+		synchronized (this) {
+			counter = notifications.length;
+			lastTime = lastNotificationTime;
+		}
+		for (StatusBarNotification notification : notifications) {
+			long time = notification.getPostTime();
+			if (lastTime == null || time > lastTime) {
+				lastTime = time;
+			}
+		}
+		synchronized (this) {
+			lastNotificationTime = lastTime;
+		}
+	}
+
+	public static void requirePermissions(@NonNull Context context) {
+		if (isPermissionRequired(context)) {
+			requestNotificationPermission(context);
+		}
+	}
+
+	public static boolean isPermissionRequired(@NonNull Context context) {
+		ComponentName cn = new ComponentName(context, NotificationService.class);
+		String flat = Settings.Secure.getString(context.getContentResolver(),
+			"enabled_notification_listeners");
+		final boolean enabled = flat != null && flat.contains(cn.flattenToString());
+		return !enabled;
+	}
+
+	private static void requestNotificationPermission(@NonNull Context context) {
+		new Handler(Looper.getMainLooper()).post(() -> new AlertDialog.Builder(context)
+			.setTitle(R.string.enable_notification_listener_title)
+			.setMessage(R.string.enable_notification_listener)
+			.setPositiveButton(R.string.go_to_settings, (dialog, id) -> {
+				Intent intent = new Intent("android.settings" +
+					".ACTION_NOTIFICATION_LISTENER_SETTINGS");
+				context.startActivity(intent);
+			})
+			.setNegativeButton(android.R.string.cancel, (dialog, id) -> dialog.dismiss())
+			.show());
+	}
+
+
+	public static int getCount() {
+		return counter;
+	}
+
+	@Nullable
+	public static Long getLastNotificationTime() {
+		return lastNotificationTime;
+	}
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,7 @@
 	<string name="linear_acceleration_vector">Linear acceleration in m/s^2</string>
 	<string name="gravity_vector">Gravity vector in m/s^2</string>
 	<string name="gyroscope">Rate of rotation in rad/s around the device\'s x, y, and z axis integrated over time</string>
+	<string name="last_notification_time">Time since the last notification. Is NaN if no notifications have happened yet.</string>
 	<string name="device_orientation">Azimuth (-π to π), pitch (-π to π) and roll (-π/2 to π/2) of the device</string>
 	<string name="device_inclination">Geomagnetic inclination angle of the device in radians</string>
 	<string name="device_rotation_matrix">Rotation matrix around the world\'s coordinate system, that is, when the device\'s X axis points toward East, the Y axis points to the North Pole and the device is facing the sky</string>
@@ -124,6 +125,7 @@
 	<string name="device_inclination_matrix">Rotation matrix transforming the geomagnetic vector into the same coordinate space as gravity</string>
 	<string name="magnetic_field">Geomagnetic field strength along the x, y and z axis in μT</string>
 	<string name="night_mode">Night mode, 1 if set, 0 if not</string>
+	<string name="notification_count">Count of active notifications</string>
 	<string name="light">Ambient light level in SI lux units</string>
 	<string name="pressure">Atmospheric pressure in hPa (millibar)</string>
 	<string name="proximity">Proximity sensor distance measured in centimeters</string>
@@ -259,4 +261,7 @@
 	<string name="show_line_numbers">Show Line Numbers</string>
 	<string name="show_line_numbers_summary">Show Line Numbers at the start of each line.</string>
 	<string name="menu_btn">More options</string>
+	<string name="enable_notification_listener">To use the notificationCount or lastNotificationTime uniform, please enable the Notification Listener in Settings.</string>
+	<string name="go_to_settings">Go to Settings</string>
+	<string name="enable_notification_listener_title">Enable Notification Listener</string>
 </resources>


### PR DESCRIPTION
This adds the `notificationCount` and `lastNotificationTime` uniforms using a `NotificationListenerService`. The user gets asked for the permission every time he opens a shader using these uniforms if he has not yet accepted the permission.

Closes #136 