### PR TITLE
Fix Shader Editor `inputType`

### DIFF
--- a/app/src/main/java/de/markusfisch/android/shadereditor/preference/Preferences.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/preference/Preferences.java
@@ -40,6 +40,7 @@ public class Preferences {
 	public static final String SHOW_LINE_NUMBERS = "show_line_numbers";
 	public static final String SHOW_EXTRA_KEYS = "show_extra_keys";
 	public static final String AUTO_HIDE_EXTRA_KEYS = "auto_hide_extra_keys";
+	public static final String HIDE_NATIVE_SUGGESTIONS = "hide_native_suggestions";
 
 	private static final int RUN_AUTO = 1;
 	private static final int RUN_MANUALLY = 2;
@@ -79,6 +80,7 @@ public class Preferences {
 	private boolean showLineNumbers = true;
 	private boolean showExtraKeys = true;
 	private boolean autoHideExtraKeys = true;
+	private boolean hideNativeSuggestions = true;
 	private String defaultFont;
 
 	public void init(Context context) {
@@ -162,10 +164,17 @@ public class Preferences {
 		autoHideExtraKeys = preferences.getBoolean(
 				AUTO_HIDE_EXTRA_KEYS,
 				autoHideExtraKeys);
+		hideNativeSuggestions = preferences.getBoolean(
+				HIDE_NATIVE_SUGGESTIONS,
+				hideNativeSuggestions);
 	}
 
 	public boolean autoHideExtraKeys() {
 		return autoHideExtraKeys;
+	}
+
+	public boolean hideNativeSuggestions() {
+		return hideNativeSuggestions;
 	}
 
 	private @NonNull Typeface loadFont(

--- a/app/src/main/java/de/markusfisch/android/shadereditor/widget/ShaderEditor.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/widget/ShaderEditor.java
@@ -290,7 +290,9 @@ public class ShaderEditor extends LineNumberEditText {
 	@Override
 	public InputConnection onCreateInputConnection(@NonNull EditorInfo outAttrs) {
 		InputConnection connection = super.onCreateInputConnection(outAttrs);
-		outAttrs.inputType = InputType.TYPE_NULL;
+		if (ShaderEditorApp.preferences.hideNativeSuggestions()) {
+			outAttrs.inputType = InputType.TYPE_NULL;
+		}
 		return connection;
 	}
 

--- a/app/src/main/java/de/markusfisch/android/shadereditor/widget/ShaderEditor.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/widget/ShaderEditor.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.text.Editable;
 import android.text.InputFilter;
+import android.text.InputType;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -20,6 +21,8 @@ import android.text.style.ReplacementSpan;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
@@ -281,6 +284,14 @@ public class ShaderEditor extends LineNumberEditText {
 	@Override
 	public int getAutofillType() {
 		return AUTOFILL_TYPE_NONE;
+	}
+
+	@Nullable
+	@Override
+	public InputConnection onCreateInputConnection(@NonNull EditorInfo outAttrs) {
+		InputConnection connection = super.onCreateInputConnection(outAttrs);
+		outAttrs.inputType = InputType.TYPE_NULL;
+		return connection;
 	}
 
 	@Override

--- a/app/src/main/res/layout/fragment_editor.xml
+++ b/app/src/main/res/layout/fragment_editor.xml
@@ -27,7 +27,7 @@
 			android:gravity="left|top"
 			android:imeOptions="flagNoExtractUi"
 			android:importantForAutofill="no"
-			android:inputType="textMultiLine|textVisiblePassword|textNoSuggestions"
+			android:inputType="textMultiLine|textNoSuggestions"
 			android:paddingHorizontal="@dimen/editor_padding"
 			android:paddingTop="@dimen/editor_padding"
 			android:textColor="@color/editor_text"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,4 +269,6 @@
 	<string name="enable_notification_listener">To use the notificationCount or lastNotificationTime uniform, please enable the Notification Listener in Settings.</string>
 	<string name="go_to_settings">Go to Settings</string>
 	<string name="enable_notification_listener_title">Enable Notification Listener</string>
+	<string name="hide_native_suggestions">Hide native suggestions</string>
+	<string name="hide_native_suggestions_summary">Hides the soft keyboard\'s suggestions. If problems arise, turn this setting off.</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -104,6 +104,12 @@
 			android:summary="@string/auto_hide_extra_keys_summary"
 			android:checked="true"
 			android:defaultValue="true"/>
+		<androidx.preference.SwitchPreferenceCompat
+			android:key="hide_native_suggestions"
+			android:title="@string/hide_native_suggestions"
+			android:summary="@string/hide_native_suggestions_summary"
+			android:checked="true"
+			android:defaultValue="true"/>
 		<de.markusfisch.android.shadereditor.preference.ShaderListPreference
 			android:key="default_new_shader"
 			android:title="@string/default_new_shader"/>


### PR DESCRIPTION
Some soft keyboard apps do not work with `textVisiblePassword`, which is a workaround in itself. This fix makes ShaderEditor behave a bit more like Termux by passing `InputType.TEXT_NULL` as the inputType inside `onCreateInputConnection`. Thanks to @StaticReasons for the detailed report, which helped me find a solution so quickly.

Overall, the suggestion bar is finicky to get working correctly on all devices, so I also added a setting to enable native suggestions.

Also, I did not add ukrainian translations, because I don't speak ukrainian and don't want to be the one adding incorrect translations. Of course, someone could add them using deepl or Google Translate but I can't evaluate their ukrainian translation quality.

Fixes #188