### PR TITLE
Fix extra keys padding

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,7 +3,7 @@
 	<dimen name="menu_item_height">48dp</dimen>
 	<!-- menu_width = 5 * menu_item_height -->
 	<dimen name="menu_width">240dp</dimen>
-	<dimen name="extra_key_row_padding">6dp</dimen>
+	<dimen name="extra_key_row_padding">3dp</dimen>
 	<dimen name="extra_key_height">40dp</dimen>
 	<dimen name="extra_key_tab_width">36dp</dimen>
 	<dimen name="extra_key_width">64dp</dimen>


### PR DESCRIPTION
I miscalculated the padding while changing the extra keys row and accidentally doubled the vertical padding of the extra keys. This commit reduces the padding to make the extra keys not take up that much vertical space again.