### PR TITLE
Improve the code completions

### DIFF
--- a/app/src/main/java/de/markusfisch/android/shadereditor/widget/ShaderEditor.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/widget/ShaderEditor.java
@@ -537,11 +537,20 @@ public class ShaderEditor extends LineNumberEditText {
 			return;
 		}
 		int positionInToken = start - tok.startOffset();
+		List<String> completions = Lexer.completeKeyword(
+				Lexer.tokenSource(tok, text).subSequence(0, positionInToken).toString(),
+				tok.category());
+
+		if (completions.isEmpty()) {
+			completions = DEFAULT_COMPLETIONS;
+			positionInToken = 0;
+		}
+		if (completions.size() == 1 && completions.get(0).contentEquals(text.subSequence(tok.startOffset(), start))) {
+			completions = DEFAULT_COMPLETIONS;
+			positionInToken = 0;
+		}
 		listener.onCodeCompletions(
-				Lexer.completeKeyword(
-						Lexer.tokenSource(tok, text).subSequence(0, positionInToken).toString(),
-						tok.category()
-				),
+				completions,
 				positionInToken);
 	}
 


### PR DESCRIPTION
If only one completion is left and it is fully typed already, there is no reason to show a single suggestion. This should resolve what @StaticReasons had noticed. The issue was the following: after writing `vec4`, the editor would still show the `vec4` suggestion, even though the user probably wants to see the `(` suggestion.

I wrote this on the go using Termux, so the formatting might not align with Android Studio's standards.