### PR TITLE
Refactor Option menu (and Add Uniform pages)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
 	}
 
 	compileOptions {
-		sourceCompatibility = JavaVersion.VERSION_1_8
-		targetCompatibility = JavaVersion.VERSION_1_8
+		sourceCompatibility = JavaVersion.VERSION_17
+		targetCompatibility = JavaVersion.VERSION_17
 	}
 }
 

--- a/app/src/main/java/de/markusfisch/android/shadereditor/activity/AddUniformActivity.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/activity/AddUniformActivity.java
@@ -4,16 +4,32 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.MenuInflater;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 
 import de.markusfisch.android.shadereditor.fragment.UniformPagesFragment;
+import de.markusfisch.android.shadereditor.widget.SearchMenu;
 
 public class AddUniformActivity extends AbstractContentActivity {
 	public static final String STATEMENT = "statement";
 	public static final int PICK_IMAGE = 1;
 	public static final int CROP_IMAGE = 2;
 	public static final int PICK_TEXTURE = 3;
+
+	private SearchMenu.OnSearchListener onSearchListener;
+
+	@Nullable
+	private String currentSearchQuery = null;
+
+	@Nullable
+	public String getCurrentSearchQuery() {
+		return currentSearchQuery;
+	}
 
 	public static void setAddUniformResult(Activity activity, String name) {
 		Bundle bundle = new Bundle();
@@ -23,6 +39,31 @@ public class AddUniformActivity extends AbstractContentActivity {
 		data.putExtras(bundle);
 
 		activity.setResult(RESULT_OK, data);
+	}
+
+	public void setSearchListener(SearchMenu.OnSearchListener onSearchListener) {
+		this.onSearchListener = onSearchListener;
+	}
+
+	@Override
+	protected void onCreate(Bundle state) {
+		super.onCreate(state);
+		addMenuProvider(new MenuProvider() {
+			@Override
+			public void onCreateMenu(@NonNull android.view.Menu menu,
+					@NonNull MenuInflater menuInflater) {
+				SearchMenu.addSearchMenu(menu, menuInflater,
+						(value) -> {
+							currentSearchQuery = value;
+							onSearchListener.filter(value);
+						});
+			}
+
+			@Override
+			public boolean onMenuItemSelected(@NonNull android.view.MenuItem menuItem) {
+				return false;
+			}
+		}, this, Lifecycle.State.RESUMED);
 	}
 
 	@Override

--- a/app/src/main/java/de/markusfisch/android/shadereditor/adapter/UniformPageAdapter.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/adapter/UniformPageAdapter.java
@@ -1,60 +1,48 @@
 package de.markusfisch.android.shadereditor.adapter;
 
-import android.content.Context;
-
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentStatePagerAdapter;
+import androidx.lifecycle.Lifecycle;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
+
+import com.google.android.material.tabs.TabLayout;
+import com.google.android.material.tabs.TabLayoutMediator.TabConfigurationStrategy;
 
 import de.markusfisch.android.shadereditor.R;
 import de.markusfisch.android.shadereditor.fragment.UniformPresetPageFragment;
 import de.markusfisch.android.shadereditor.fragment.UniformSampler2dPageFragment;
 import de.markusfisch.android.shadereditor.fragment.UniformSamplerCubePageFragment;
 
-public class UniformPageAdapter extends FragmentStatePagerAdapter {
-	private final Context context;
+public class UniformPageAdapter extends FragmentStateAdapter implements TabConfigurationStrategy {
 
-	public UniformPageAdapter(Context context, FragmentManager fm) {
-		super(fm);
-		this.context = context;
-	}
 
-	@Override
-	public int getCount() {
-		return 3;
+	public UniformPageAdapter(@NonNull FragmentManager fragmentManager,
+			@NonNull Lifecycle lifecycle) {
+		super(fragmentManager, lifecycle);
 	}
 
 	@NonNull
 	@Override
-	public Fragment getItem(int position) {
-		switch (position) {
-			default:
-			case 0:
-				return new UniformPresetPageFragment();
-			case 1:
-				return new UniformSampler2dPageFragment();
-			case 2:
-				return new UniformSamplerCubePageFragment();
-		}
+	public Fragment createFragment(int position) {
+		return switch (position) {
+			default -> new UniformPresetPageFragment();
+			case 1 -> new UniformSampler2dPageFragment();
+			case 2 -> new UniformSamplerCubePageFragment();
+		};
 	}
 
 	@Override
-	public CharSequence getPageTitle(int position) {
-		int id;
-		switch (position) {
-			default:
-			case 0:
-				id = R.string.preset;
-				break;
-			case 1:
-				id = R.string.sampler_2d;
-				break;
-			case 2:
-				id = R.string.sampler_cube;
-				break;
-		}
+	public int getItemCount() {
+		return 3;
+	}
 
-		return context.getString(id);
+	@Override
+	public void onConfigureTab(@NonNull TabLayout.Tab tab, int position) {
+		tab.setText(switch (position) {
+			default -> R.string.preset;
+			case 1 -> R.string.sampler_2d;
+			case 2 -> R.string.sampler_cube;
+		});
 	}
 }

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/AddUniformPageFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/AddUniformPageFragment.java
@@ -1,0 +1,23 @@
+package de.markusfisch.android.shadereditor.fragment;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import de.markusfisch.android.shadereditor.activity.AddUniformActivity;
+
+public abstract class AddUniformPageFragment extends Fragment {
+
+	@Override
+	public void onResume() {
+		super.onResume();
+		if (requireActivity() instanceof AddUniformActivity addUniformActivity) {
+			addUniformActivity.setSearchListener(this::onSearch);
+			var currentSearchQuery = addUniformActivity.getCurrentSearchQuery();
+			if (currentSearchQuery != null) {
+				onSearch(currentSearchQuery);
+			}
+		}
+	}
+
+	protected abstract void onSearch(@Nullable String query);
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CropImageFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CropImageFragment.java
@@ -7,7 +7,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.LayoutInflater;
-import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -15,7 +14,9 @@ import android.view.ViewGroup;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 
 import java.util.concurrent.Executors;
 
@@ -39,7 +40,6 @@ public class CropImageFragment extends Fragment {
 	@Override
 	public void onCreate(Bundle state) {
 		super.onCreate(state);
-		setHasOptionsMenu(true);
 	}
 
 	@Override
@@ -80,6 +80,23 @@ public class CropImageFragment extends Fragment {
 
 		view.findViewById(R.id.crop).setOnClickListener(v -> cropImage());
 
+		requireActivity().addMenuProvider(new MenuProvider() {
+			@Override
+			public void onCreateMenu(@NonNull android.view.Menu menu,
+					@NonNull MenuInflater menuInflater) {
+				menuInflater.inflate(R.menu.fragment_crop_image, menu);
+			}
+
+			@Override
+			public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+				if (menuItem.getItemId() == R.id.rotate_clockwise) {
+					rotateClockwise();
+					return true;
+				}
+				return false;
+			}
+		}, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
+
 		return view;
 	}
 
@@ -87,20 +104,6 @@ public class CropImageFragment extends Fragment {
 	public void onResume() {
 		super.onResume();
 		loadBitmapAsync();
-	}
-
-	@Override
-	public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
-		inflater.inflate(R.menu.fragment_crop_image, menu);
-	}
-
-	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
-		if (item.getItemId() == R.id.rotate_clockwise) {
-			rotateClockwise();
-			return true;
-		}
-		return super.onOptionsItemSelected(item);
 	}
 
 	private void loadBitmapAsync() {

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CubeMapFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CubeMapFragment.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -13,7 +12,9 @@ import android.view.ViewGroup;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 
 import de.markusfisch.android.shadereditor.R;
 import de.markusfisch.android.shadereditor.activity.AbstractSubsequentActivity;
@@ -64,21 +65,24 @@ public class CubeMapFragment extends Fragment {
 		// Make cubeMapView in activity visible (again).
 		cubeMapView.setVisibility(View.VISIBLE);
 
+		requireActivity().addMenuProvider(new MenuProvider() {
+			@Override
+			public void onCreateMenu(@NonNull android.view.Menu menu,
+					@NonNull MenuInflater menuInflater) {
+				menuInflater.inflate(R.menu.fragment_crop_image, menu);
+			}
+
+			@Override
+			public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+				if (menuItem.getItemId() == R.id.rotate_clockwise) {
+					rotateClockwise();
+					return true;
+				}
+				return false;
+			}
+		}, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
+
 		return view;
-	}
-
-	@Override
-	public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
-		inflater.inflate(R.menu.fragment_crop_image, menu);
-	}
-
-	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
-		if (item.getItemId() == R.id.rotate_clockwise) {
-			rotateClockwise();
-			return true;
-		}
-		return super.onOptionsItemSelected(item);
 	}
 
 	@Override

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/TextureViewFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/TextureViewFragment.java
@@ -6,7 +6,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.LayoutInflater;
-import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -14,7 +13,9 @@ import android.view.ViewGroup;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -41,7 +42,6 @@ public class TextureViewFragment extends Fragment {
 	@Override
 	public void onCreate(Bundle state) {
 		super.onCreate(state);
-		setHasOptionsMenu(true);
 	}
 
 	@Override
@@ -105,21 +105,24 @@ public class TextureViewFragment extends Fragment {
 		view.findViewById(R.id.insert_code).setOnClickListener(
 				v -> insertUniformSamplerStatement());
 
+		requireActivity().addMenuProvider(new MenuProvider() {
+			@Override
+			public void onCreateMenu(@NonNull android.view.Menu menu,
+					@NonNull MenuInflater menuInflater) {
+				menuInflater.inflate(R.menu.fragment_view_texture, menu);
+			}
+
+			@Override
+			public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+				if (menuItem.getItemId() == R.id.remove_texture) {
+					askToRemoveTexture(textureId);
+					return true;
+				}
+				return false;
+			}
+		}, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
+
 		return view;
-	}
-
-	@Override
-	public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
-		inflater.inflate(R.menu.fragment_view_texture, menu);
-	}
-
-	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
-		if (item.getItemId() == R.id.remove_texture) {
-			askToRemoveTexture(textureId);
-			return true;
-		}
-		return super.onOptionsItemSelected(item);
 	}
 
 	private void askToRemoveTexture(final long id) {

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/UniformPagesFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/UniformPagesFragment.java
@@ -8,8 +8,9 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.viewpager.widget.PagerTabStrip;
-import androidx.viewpager.widget.ViewPager;
+import androidx.viewpager2.widget.ViewPager2;
+
+import com.google.android.material.tabs.TabLayoutMediator;
 
 import de.markusfisch.android.shadereditor.R;
 import de.markusfisch.android.shadereditor.adapter.UniformPageAdapter;
@@ -31,17 +32,10 @@ public class UniformPagesFragment extends Fragment {
 				container,
 				false);
 
-		ViewPager viewPager = view.findViewById(R.id.pager);
-		viewPager.setAdapter(new UniformPageAdapter(
-				getActivity(),
-				getChildFragmentManager()));
-
-		// Workaround to make sure PagerTabStrip is visible in a release
-		// build. Without this, it will only be visible in a debug build.
-		// See: https://code.google.com/p/android/issues/detail?id=213359
-		PagerTabStrip pagerTabStrip = view.findViewById(R.id.pagerTabStrip);
-		((ViewPager.LayoutParams) pagerTabStrip.getLayoutParams())
-				.isDecor = true;
+		ViewPager2 viewPager = view.findViewById(R.id.pager);
+		var adapter = new UniformPageAdapter(getChildFragmentManager(), getLifecycle());
+		viewPager.setAdapter(adapter);
+		new TabLayoutMediator(view.findViewById(R.id.tab_layout), viewPager, adapter).attach();
 
 		return view;
 	}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/UniformPresetPageFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/UniformPresetPageFragment.java
@@ -4,30 +4,21 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
+import androidx.annotation.Nullable;
 
 import de.markusfisch.android.shadereditor.R;
 import de.markusfisch.android.shadereditor.activity.AbstractSubsequentActivity;
 import de.markusfisch.android.shadereditor.activity.AddUniformActivity;
 import de.markusfisch.android.shadereditor.adapter.PresetUniformAdapter;
-import de.markusfisch.android.shadereditor.widget.SearchMenu;
 
-public class UniformPresetPageFragment extends Fragment {
+public class UniformPresetPageFragment extends AddUniformPageFragment {
 	private PresetUniformAdapter uniformsAdapter;
 	private ListView listView;
-
-	@Override
-	public void onCreate(Bundle state) {
-		super.onCreate(state);
-		setHasOptionsMenu(true);
-	}
 
 	@Override
 	public View onCreateView(
@@ -39,8 +30,7 @@ public class UniformPresetPageFragment extends Fragment {
 				container,
 				false);
 
-		Activity activity = getActivity();
-
+		Activity activity = requireActivity();
 		listView = view.findViewById(R.id.uniforms);
 		initListView(activity);
 
@@ -48,16 +38,12 @@ public class UniformPresetPageFragment extends Fragment {
 	}
 
 	@Override
-	public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-		SearchMenu.addSearchMenu(menu, inflater, this::filterUniforms);
+	protected void onSearch(@Nullable String query) {
+		uniformsAdapter.getFilter().filter(query,
+				count -> uniformsAdapter.notifyDataSetChanged());
 	}
 
-	private void filterUniforms(String query) {
-		uniformsAdapter.getFilter().filter(query);
-		uniformsAdapter.notifyDataSetChanged();
-	}
-
-	private void initListView(Context context) {
+	private void initListView(@NonNull Context context) {
 		uniformsAdapter = new PresetUniformAdapter(context);
 
 		listView.setAdapter(uniformsAdapter);

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/UniformSampler2dPageFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/UniformSampler2dPageFragment.java
@@ -8,14 +8,12 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
+import androidx.annotation.Nullable;
 
 import java.util.Locale;
 import java.util.concurrent.Executors;
@@ -25,9 +23,8 @@ import de.markusfisch.android.shadereditor.activity.AddUniformActivity;
 import de.markusfisch.android.shadereditor.activity.TextureViewActivity;
 import de.markusfisch.android.shadereditor.adapter.TextureAdapter;
 import de.markusfisch.android.shadereditor.app.ShaderEditorApp;
-import de.markusfisch.android.shadereditor.widget.SearchMenu;
 
-public class UniformSampler2dPageFragment extends Fragment {
+public class UniformSampler2dPageFragment extends AddUniformPageFragment {
 	protected String searchQuery;
 
 	private ListView listView;
@@ -39,7 +36,6 @@ public class UniformSampler2dPageFragment extends Fragment {
 	@Override
 	public void onCreate(Bundle state) {
 		super.onCreate(state);
-		setHasOptionsMenu(true);
 	}
 
 	@Override
@@ -82,11 +78,6 @@ public class UniformSampler2dPageFragment extends Fragment {
 		listView = null;
 		progressBar = null;
 		noTexturesMessage = null;
-	}
-
-	@Override
-	public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-		SearchMenu.addSearchMenu(menu, inflater, this::filterTextures);
 	}
 
 	public void setSamplerType(String type) {
@@ -172,7 +163,7 @@ public class UniformSampler2dPageFragment extends Fragment {
 				(parent, view1, position, id) -> showTexture(id));
 	}
 
-	private void filterTextures(String query) {
+	protected void onSearch(@Nullable String query) {
 		searchQuery = query == null
 				? null
 				: query.toLowerCase(Locale.getDefault());

--- a/app/src/main/java/de/markusfisch/android/shadereditor/widget/SearchMenu.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/widget/SearchMenu.java
@@ -4,22 +4,24 @@ import android.view.Menu;
 import android.view.MenuInflater;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
-import androidx.core.view.MenuItemCompat;
+
+import java.util.Objects;
 
 import de.markusfisch.android.shadereditor.R;
 
 public class SearchMenu {
 	public interface OnSearchListener {
-		void filter(String value);
+		void filter(@Nullable String value);
 	}
 
 	public static void addSearchMenu(@NonNull Menu menu,
-			MenuInflater inflater,
-			OnSearchListener onSearchListener) {
+			@NonNull MenuInflater inflater,
+			@NonNull OnSearchListener onSearchListener) {
 		inflater.inflate(R.menu.search, menu);
-		SearchView searchView = (SearchView)
-				MenuItemCompat.getActionView(menu.findItem(R.id.search));
+		SearchView searchView =
+				(SearchView) Objects.requireNonNull(menu.findItem(R.id.search).getActionView());
 		searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
 			@Override
 			public boolean onQueryTextChange(String newText) {

--- a/app/src/main/res/layout/fragment_uniform_pages.xml
+++ b/app/src/main/res/layout/fragment_uniform_pages.xml
@@ -1,11 +1,17 @@
-<androidx.viewpager.widget.ViewPager
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	android:id="@+id/pager"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:layout_width="match_parent"
-	android:layout_height="match_parent">
-	<androidx.viewpager.widget.PagerTabStrip
-		android:id="@+id/pagerTabStrip"
+	android:layout_height="match_parent"
+	android:orientation="vertical">
+
+	<com.google.android.material.tabs.TabLayout
+		android:id="@+id/tab_layout"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		android:background="@color/primary_translucent"/>
-</androidx.viewpager.widget.ViewPager>
+		android:background="@color/primary_translucent" />
+
+	<androidx.viewpager2.widget.ViewPager2
+		android:id="@+id/pager"
+		android:layout_width="match_parent"
+		android:layout_height="0dp"
+		android:layout_weight="1" />
+</LinearLayout>


### PR DESCRIPTION
This refactors the fragment's option menus to the newer `addMenuProvider` API. The "Add Uniform/Texture" pages have been refactored as well, because they did work with the new menu system (they all added a new search option to the top bar).