### PR TITLE
Fragments deprecations

### DIFF
--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CropImageFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CropImageFragment.java
@@ -147,7 +147,7 @@ public class CropImageFragment extends Fragment {
 
 	private void cropImage() {
 		AbstractSubsequentActivity.addFragment(
-				getFragmentManager(),
+				getParentFragmentManager(),
 				Sampler2dPropertiesFragment.newInstance(
 						imageUri,
 						cropImageView.getNormalizedRectInBounds(),

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CubeMapFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CubeMapFragment.java
@@ -115,7 +115,7 @@ public class CubeMapFragment extends Fragment {
 		}
 
 		AbstractSubsequentActivity.addFragment(
-				getFragmentManager(),
+				getParentFragmentManager(),
 				SamplerCubePropertiesFragment.newInstance(faces));
 
 		cubeMapView.setVisibility(View.GONE);

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CubeMapFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CubeMapFragment.java
@@ -33,7 +33,6 @@ public class CubeMapFragment extends Fragment {
 	@Override
 	public void onCreate(Bundle state) {
 		super.onCreate(state);
-		setHasOptionsMenu(true);
 
 		// Register the ActivityResultLauncher for picking an image
 		pickImageLauncher = registerForActivityResult(

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/PreferencesFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/PreferencesFragment.java
@@ -96,10 +96,10 @@ public class PreferencesFragment
 	@Override
 	public void onResume() {
 		super.onResume();
-
-		getPreferenceScreen()
-				.getSharedPreferences()
-				.registerOnSharedPreferenceChangeListener(this);
+		SharedPreferences preferences = getPreferenceScreen().getSharedPreferences();
+		if (preferences != null) {
+			preferences.registerOnSharedPreferenceChangeListener(this);
+		}
 
 		setSummaries(getPreferenceScreen());
 	}
@@ -108,9 +108,10 @@ public class PreferencesFragment
 	public void onPause() {
 		super.onPause();
 
-		getPreferenceScreen()
-				.getSharedPreferences()
-				.unregisterOnSharedPreferenceChangeListener(this);
+		SharedPreferences preferences = getPreferenceScreen().getSharedPreferences();
+		if (preferences != null) {
+			preferences.unregisterOnSharedPreferenceChangeListener(this);
+		}
 	}
 
 	@Override
@@ -134,13 +135,14 @@ public class PreferencesFragment
 
 	@Override
 	public void onDisplayPreferenceDialog(@NonNull Preference preference) {
-		if (preference instanceof ShaderListPreference) {
-			DialogFragment f = ShaderListPreferenceDialogFragment
-					.newInstance(preference.getKey());
-
+		if (preference instanceof ShaderListPreference listPreference) {
+			String key = listPreference.getKey();
+			DialogFragment f = ShaderListPreferenceDialogFragment.newInstance(key);
+			// FIXME: Periodically check whether androidx.preference still uses TargetFragment
+			// noinspection deprecation
 			f.setTargetFragment(this, 0);
-			f.show(getFragmentManager(),
-					"ShaderListPreferenceDialogFragment");
+
+			f.show(getParentFragmentManager(), "ShaderListPreferenceDialogFragment");
 
 			return;
 		}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/TextureViewFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/TextureViewFragment.java
@@ -158,7 +158,7 @@ public class TextureViewFragment extends Fragment {
 	private void insertUniformSamplerStatement() {
 		imageView.setVisibility(View.GONE);
 		AbstractSubsequentActivity.addFragment(
-				getFragmentManager(),
+				getParentFragmentManager(),
 				TextureParametersFragment.newInstance(
 						samplerType,
 						textureName));

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/UniformPresetPageFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/UniformPresetPageFragment.java
@@ -57,7 +57,7 @@ public class UniformPresetPageFragment extends AddUniformPageFragment {
 	private void addUniform(PresetUniformAdapter.Uniform uniform) {
 		if (uniform.isSampler()) {
 			AbstractSubsequentActivity.addFragment(
-					getParentFragment().getFragmentManager(),
+					requireParentFragment().getParentFragmentManager(),
 					TextureParametersFragment.newInstance(
 							uniform.type,
 							uniform.name));


### PR DESCRIPTION
This replaces `getFragmentManager` with `getParentFragmentManager`.

- Also replaces `getParentFragment` with `requireParentFragment`, because of nullability

- `androidx.preference` still relies on `TargetFragment`, so a `FIXME` comment was added to remember contributors to periodically check if this is still needed