### PR TITLE
Fix: Ensure non-premultiplied alpha for textures

### DIFF
--- a/app/src/main/java/de/markusfisch/android/shadereditor/database/dao/TextureDao.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/database/dao/TextureDao.java
@@ -81,7 +81,9 @@ public class TextureDao {
 			if (cursor.moveToFirst()) {
 				var data = CursorHelpers.getBlob(cursor, DatabaseContract.TextureColumns.MATRIX);
 				if (data != null) {
-					return BitmapFactory.decodeByteArray(data, 0, data.length);
+					BitmapFactory.Options options = new BitmapFactory.Options();
+					options.inPremultiplied = false;
+					return BitmapFactory.decodeByteArray(data, 0, data.length, options);
 				}
 			}
 		} catch (OutOfMemoryError e) {
@@ -101,7 +103,9 @@ public class TextureDao {
 			if (cursor.moveToFirst()) {
 				var data = CursorHelpers.getBlob(cursor, DatabaseContract.TextureColumns.MATRIX);
 				if (data != null) {
-					return BitmapFactory.decodeByteArray(data, 0, data.length);
+					BitmapFactory.Options options = new BitmapFactory.Options();
+					options.inPremultiplied = false;
+					return BitmapFactory.decodeByteArray(data, 0, data.length, options);
 				}
 			}
 		} catch (OutOfMemoryError e) {
@@ -129,8 +133,7 @@ public class TextureDao {
 	private static long insertTexture(SQLiteDatabase db, String name, Bitmap bitmap,
 			int thumbnailSize) {
 		try {
-			var thumbnail = Bitmap.createScaledBitmap(bitmap, thumbnailSize, thumbnailSize,
-					true);
+			var thumbnail = BitmapEditor.createScaledBitmapManual(bitmap, thumbnailSize, thumbnailSize);
 			int w = bitmap.getWidth();
 			int h = bitmap.getHeight();
 			return insertTexture(db, name, w, h, calculateRatio(w, h),
@@ -236,8 +239,10 @@ public class TextureDao {
 			}
 
 			private void insertInitialTextures(@NonNull SQLiteDatabase db) {
+				BitmapFactory.Options options = new BitmapFactory.Options();
+				options.inPremultiplied = false;
 				Bitmap noiseBitmap = BitmapFactory.decodeResource(context.getResources(),
-						R.drawable.texture_noise);
+						R.drawable.texture_noise, options);
 				int thumbnailSize =
 						Math.round(context.getResources().getDisplayMetrics().density * 48f);
 				insertTexture(db,
@@ -270,7 +275,9 @@ public class TextureDao {
 							continue;
 						}
 
-						var bm = BitmapFactory.decodeByteArray(data, 0, data.length);
+						BitmapFactory.Options options = new BitmapFactory.Options();
+						options.inPremultiplied = false;
+						var bm = BitmapFactory.decodeByteArray(data, 0, data.length, options);
 						if (bm == null) {
 							continue;
 						}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CropImageFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/CropImageFragment.java
@@ -130,8 +130,20 @@ public class CropImageFragment extends Fragment {
 				}
 
 				if (isAdded()) {
-					bitmap = b;
-					cropImageView.setImageBitmap(b);
+					if (bitmap != null) {
+						bitmap.recycle();
+					}
+					// `b` is non-premultiplied. We need a premultiplied one for display.
+					if (b.hasAlpha() && !b.isPremultiplied()) {
+						// Create a premultiplied copy for display.
+						Bitmap premultipliedBitmap = b.copy(b.getConfig(), true);
+						premultipliedBitmap.setPremultiplied(true);
+						b.recycle();
+						bitmap = premultipliedBitmap;
+					} else {
+						bitmap = b;
+					}
+					cropImageView.setImageBitmap(bitmap);
 				}
 			});
 		});

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/Sampler2dPropertiesFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/Sampler2dPropertiesFragment.java
@@ -113,13 +113,12 @@ public class Sampler2dPropertiesFragment extends AbstractSamplerPropertiesFragme
 		// Get the DataSource using the modern singleton pattern.
 		DataSource dataSource = Database.getInstance(context).getDataSource();
 
-		if (dataSource.texture.insertTexture(
-				name,
-				Bitmap.createScaledBitmap(
-						bitmap,
-						size,
-						size,
-						true)) < 1) {
+		Bitmap scaledBitmap = BitmapEditor.createScaledBitmapManual(
+				bitmap,
+				size,
+				size);
+
+		if (dataSource.texture.insertTexture(name, scaledBitmap) < 1) {
 			return R.string.name_already_taken;
 		}
 

--- a/app/src/main/java/de/markusfisch/android/shadereditor/fragment/TextureViewFragment.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/fragment/TextureViewFragment.java
@@ -73,10 +73,10 @@ public class TextureViewFragment extends Fragment {
 		}
 
 		// Fetch texture info and bitmap using the modern DataSource.
-		Bitmap textureBitmap = dataSource.texture.getTextureBitmap(textureId);
+		Bitmap nonPremultipliedBitmap = dataSource.texture.getTextureBitmap(textureId);
 		TextureInfo textureInfo = dataSource.texture.getTextureInfo(textureId);
 
-		if (textureBitmap == null || textureInfo == null) {
+		if (nonPremultipliedBitmap == null || textureInfo == null) {
 			// Automatically remove defective textures.
 			dataSource.texture.removeTexture(textureId);
 			Toast.makeText(activity, R.string.removed_invalid_texture,
@@ -84,6 +84,16 @@ public class TextureViewFragment extends Fragment {
 			activity.finish();
 			return null;
 		}
+
+		Bitmap textureBitmap;
+		if (nonPremultipliedBitmap.hasAlpha() && !nonPremultipliedBitmap.isPremultiplied()) {
+			textureBitmap = nonPremultipliedBitmap.copy(nonPremultipliedBitmap.getConfig(), true);
+			textureBitmap.setPremultiplied(true);
+			nonPremultipliedBitmap.recycle();
+		} else {
+			textureBitmap = nonPremultipliedBitmap;
+		}
+
 
 		textureName = textureInfo.name();
 		activity.setTitle(textureName);

--- a/app/src/main/java/de/markusfisch/android/shadereditor/graphics/BitmapEditor.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/graphics/BitmapEditor.java
@@ -8,14 +8,17 @@ import android.graphics.Matrix;
 import android.graphics.RectF;
 import android.net.Uri;
 import android.os.Build;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.jetbrains.annotations.Contract;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 public class BitmapEditor {
 	@NonNull
@@ -34,8 +37,9 @@ public class BitmapEditor {
 		return out.toByteArray();
 	}
 
+	@Nullable
 	public static Bitmap getBitmapFromUri(
-			Context context,
+			@NonNull Context context,
 			Uri uri,
 			int maxSize) {
 		InputStream in = null;
@@ -45,6 +49,7 @@ public class BitmapEditor {
 				return null;
 			}
 			BitmapFactory.Options options = new BitmapFactory.Options();
+			options.inPremultiplied = false;
 			setSampleSize(options, in, maxSize, maxSize);
 
 			in.close();
@@ -68,16 +73,20 @@ public class BitmapEditor {
 			Bitmap bitmap,
 			RectF rect,
 			float rotation) {
-		if (bitmap == null) {
+
+		if (bitmap == null || bitmap.isRecycled()) {
 			return null;
 		}
 
 		try {
+			Bitmap sourceBitmap = bitmap;
+
+			// 1. Handle rotation. This step may produce an intermediate premultiplied bitmap,
+			// but that's okay because we will be extracting its pixels manually.
 			if (rotation % 360f != 0) {
 				Matrix matrix = new Matrix();
 				matrix.setRotate(rotation);
-
-				bitmap = Bitmap.createBitmap(
+				sourceBitmap = Bitmap.createBitmap(
 						bitmap,
 						0,
 						0,
@@ -87,22 +96,128 @@ public class BitmapEditor {
 						true);
 			}
 
-			float w = bitmap.getWidth();
-			float h = bitmap.getHeight();
+			// 2. Calculate the crop area in pixels
+			int srcWidth = sourceBitmap.getWidth();
+			int srcHeight = sourceBitmap.getHeight();
+			int cropX = Math.round(rect.left * srcWidth);
+			int cropY = Math.round(rect.top * srcHeight);
+			int cropWidth = Math.round(rect.width() * srcWidth);
+			int cropHeight = Math.round(rect.height() * srcHeight);
 
-			return Bitmap.createBitmap(
-					bitmap,
-					Math.round(rect.left * w),
-					Math.round(rect.top * h),
-					Math.round(rect.width() * w),
-					Math.round(rect.height() * h));
+			// 3. Validate crop dimensions
+			if (cropWidth <= 0 || cropHeight <= 0 || cropX < 0 || cropY < 0 ||
+					cropX + cropWidth > srcWidth || cropY + cropHeight > srcHeight) {
+				Log.e("BitmapUtils", "Invalid crop parameters.");
+				return null;
+			}
+
+			// 4. *** The Core Logic: Manual Pixel Copy ***
+			// Create an array to hold the cropped pixels.
+			int[] croppedPixels = new int[cropWidth * cropHeight];
+
+			// Extract the rectangular block of pixels from the source bitmap.
+			// This is a highly optimized, low-level copy.
+			sourceBitmap.getPixels(croppedPixels, 0, cropWidth, cropX, cropY, cropWidth,
+					cropHeight);
+
+			// 5. Create the final bitmap from the array of cropped pixels.
+			// getPixels() always returns non-premultiplied pixels. We create a
+			// new non-premultiplied bitmap from them. We cannot use
+			// createBitmap(pixels...) as that always creates a premultiplied
+			// bitmap.
+			Bitmap croppedBitmap = Bitmap.createBitmap(cropWidth, cropHeight,
+					Objects.requireNonNull(sourceBitmap.getConfig()));
+			croppedBitmap.setPremultiplied(false);
+			croppedBitmap.setPixels(croppedPixels, 0, cropWidth, 0, 0, cropWidth, cropHeight);
+
+			return croppedBitmap;
+
 		} catch (OutOfMemoryError | IllegalArgumentException e) {
+			Log.e("BitmapEditor", "Failed to crop bitmap", e);
 			return null;
 		}
 	}
 
+	/**
+	 * Scales a bitmap using manual bilinear interpolation to preserve color data
+	 * in pixels with zero alpha. This method avoids the Android Canvas and its
+	 * destructive premultiplication behavior.
+	 *
+	 * @param src       The source bitmap, which must be non-premultiplied.
+	 * @param dstWidth  The width of the new bitmap.
+	 * @param dstHeight The height of the new bitmap.
+	 * @return The new scaled bitmap, in a non-premultiplied state.
+	 */
+	@NonNull
+	public static Bitmap createScaledBitmapManual(
+			@NonNull Bitmap src, int dstWidth, int dstHeight) {
+
+		int srcWidth = src.getWidth();
+		int srcHeight = src.getHeight();
+
+		int[] srcPixels = new int[srcWidth * srcHeight];
+		src.getPixels(srcPixels, 0, srcWidth, 0, 0, srcWidth, srcHeight);
+
+		int[] dstPixels = new int[dstWidth * dstHeight];
+
+		float xRatio = (float) (srcWidth - 1) / dstWidth;
+		float yRatio = (float) (srcHeight - 1) / dstHeight;
+
+		for (int y = 0; y < dstHeight; y++) {
+			for (int x = 0; x < dstWidth; x++) {
+				float gx = x * xRatio;
+				float gy = y * yRatio;
+
+				int gxi = (int) gx;
+				int gyi = (int) gy;
+
+				int c00 = srcPixels[gyi * srcWidth + gxi];
+				int c10 = srcPixels[gyi * srcWidth + gxi + 1];
+				int c01 = srcPixels[(gyi + 1) * srcWidth + gxi];
+				int c11 = srcPixels[(gyi + 1) * srcWidth + gxi + 1];
+
+				float fracX = gx - gxi;
+				float fracY = gy - gyi;
+
+				// Interpolate each channel (A, R, G, B) separately.
+				int a = (int) interpolate(
+						interpolate((c00 >> 24) & 0xff, (c10 >> 24) & 0xff, fracX),
+						interpolate((c01 >> 24) & 0xff, (c11 >> 24) & 0xff, fracX),
+						fracY);
+
+				int r = (int) interpolate(
+						interpolate((c00 >> 16) & 0xff, (c10 >> 16) & 0xff, fracX),
+						interpolate((c01 >> 16) & 0xff, (c11 >> 16) & 0xff, fracX),
+						fracY);
+
+				int g = (int) interpolate(
+						interpolate((c00 >> 8) & 0xff, (c10 >> 8) & 0xff, fracX),
+						interpolate((c01 >> 8) & 0xff, (c11 >> 8) & 0xff, fracX),
+						fracY);
+
+				int b = (int) interpolate(
+						interpolate(c00 & 0xff, c10 & 0xff, fracX),
+						interpolate(c01 & 0xff, c11 & 0xff, fracX),
+						fracY);
+
+				dstPixels[y * dstWidth + x] = (a << 24) | (r << 16) | (g << 8) | b;
+			}
+		}
+
+		Bitmap finalBitmap = Bitmap.createBitmap(
+				dstWidth, dstHeight, Objects.requireNonNull(src.getConfig()));
+		finalBitmap.setPremultiplied(false);
+		finalBitmap.setPixels(dstPixels, 0, dstWidth, 0, 0, dstWidth, dstHeight);
+
+		return finalBitmap;
+	}
+
+	private static float interpolate(float a, float b, float frac) {
+		return a * (1 - frac) + b * frac;
+	}
+
 	private static void setSampleSize(
-			BitmapFactory.Options options,
+			@NonNull BitmapFactory.Options options,
 			InputStream in,
 			int maxWidth,
 			int maxHeight) {


### PR DESCRIPTION
This pull request resolves a long-standing issue where textures with transparency were incorrectly converted to premultiplied alpha during various bitmap operations. This would cause visual artifacts like dark fringes around transparent edges, as the alpha channel was effectively being applied twice.

A big thank you to @SpartanJoe193 for reporting and providing detailed examples in both issues!

Closes #238, Closes #242.

## The Problem

As discussed in the issues, the root cause was more complex than simply setting `inPremultiplied = false` during the initial texture load. While that was the first step, the core issue was that any subsequent bitmap manipulation—like **cropping or rotating**—using standard Android methods (`Canvas`, `Matrix`) would implicitly re-premultiply the alpha channel, undoing the initial load setting and corrupting the color data in transparent areas.

## The Solution

To fix this, all standard bitmap operations within the texture processing pipeline have been replaced with manual, pixel-level transformations. These new methods correctly handle and preserve the non-premultiplied (straight alpha) state of the texture data through all steps:

*   **Loading:** Textures are now explicitly loaded with `inPremultiplied = false`.
*   **Cropping & Rotation:** Custom pixel-by-pixel logic now performs these operations, avoiding the `Canvas` and its automatic premultiplication.
*   **Scaling:** A manual bilinear interpolation implementation is used for resizing, ensuring color integrity is maintained.

> [!Note]
> The new methods are implemented in software and may be slower than the previous hardware-accelerated `Canvas` operations. This is a necessary trade-off for correctness. The performance of these new methods can be a target for future optimization.

---

## How to Verify the Fix

You can easily verify the fix using the test texture and shader below.

### 1. Test Image

Save and import the following test image. It contains three vertical bars and has an alpha gradient.

<img width="300" height="150" alt="straight_alpha_test" src="https://github.com/user-attachments/assets/2196dac6-ef82-4569-8ae2-396a1f88b115" />

### 2. Test Shader

Use this shader. It displays the texture. The left half shows the correct blending for straight alpha, while the right half simulates the old, incorrect behavior.

<details>
<summary>Click to expand the example shader</summary>

```glsl
#version 300 es

precision mediump float;

uniform sampler2D sampleTex;
uniform vec2 resolution;
uniform vec2 touch;

out vec4 fragColor;

void main() {
	fragColor = vec4(1.0);

	vec2 uv = gl_FragCoord.xy/ resolution;
	vec4 texColor = texture(sampleTex, uv);

	// 3. Determine the final color based on screen position
	float handle = touch.x;

	if (gl_FragCoord.x < handle) {
		// --- LEFT SIDE: CORRECT rendering for straight alpha ---
		fragColor.rgb = texColor.rgb;
	} else {
		// --- RIGHT SIDE: SIMULATE incorrect handling ---
		fragColor.rgb = texColor.rgb * texColor.a;
	}

	// 5. Draw a white dividing line for clarity
	if (abs(gl_FragCoord.x - handle) < 1.0) {
		fragColor = vec4(1.0); // White
	}
}
```
</details>

### 3. Steps
1.  Add the test shader to the editor.
2.  Import the test image from above as `sampleTex`.
3.  Run the shader and use touch input to move the dividing line.

### Expected Result
The left side of the preview will show the complete, solid color data. The right side will simulate the old, incorrect behavior which gets darker as the alpha drops.