### PR TITLE
Fix completion-correctness races and EOF behavior

### DIFF
--- a/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/ExtraKeysManager.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/ExtraKeysManager.java
@@ -54,8 +54,7 @@ public class ExtraKeysManager implements ViewTreeObserver.OnGlobalLayoutListener
 	}
 
 	public void setCompletions(List<String> completions, int position) {
-		completionsAdapter.setPosition(position);
-		completionsAdapter.submitList(completions);
+		completionsAdapter.submitCompletions(completions, position);
 	}
 
 	public void updateVisibility() {

--- a/app/src/main/java/de/markusfisch/android/shadereditor/adapter/CompletionsAdapter.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/adapter/CompletionsAdapter.java
@@ -12,6 +12,9 @@ import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.ListAdapter;
 import androidx.recyclerview.widget.RecyclerView;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import de.markusfisch.android.shadereditor.R;
 
 public class CompletionsAdapter extends ListAdapter<String, CompletionsAdapter.ViewHolder> {
@@ -45,8 +48,9 @@ public class CompletionsAdapter extends ListAdapter<String, CompletionsAdapter.V
 		holder.update(item);
 	}
 
-	public void setPosition(int position) {
-		this.position = position;
+	public void submitCompletions(@NonNull List<String> completions, int position) {
+		List<String> committedCompletions = new ArrayList<>(completions);
+		submitList(committedCompletions, () -> this.position = position);
 	}
 
 	public class ViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/de/markusfisch/android/shadereditor/highlighter/Lexer.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/highlighter/Lexer.java
@@ -645,7 +645,7 @@ public class Lexer implements Iterable<Token> {
 			int mid = low + (high - low) / 2;
 			Token midToken = tokens.get(mid);
 
-			if (position >= midToken.startOffset() && position <= midToken.endOffset()) {
+			if (position >= midToken.startOffset() && position < midToken.endOffset()) {
 				return midToken;
 			} else if (position < midToken.startOffset()) {
 				high = mid - 1;

--- a/app/src/main/java/de/markusfisch/android/shadereditor/widget/ShaderEditor.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/widget/ShaderEditor.java
@@ -72,10 +72,14 @@ public class ShaderEditor extends LineNumberEditText {
 		DEFAULT_COMPLETIONS.add("]");
 	}
 
+	private int revision = 0;
 	private final int[] colors = new int[Highlight.values().length];
 	private final TokenListUpdater tokenListUpdater = new TokenListUpdater(
-			(tokens, text) -> post(
-					() -> provideCompletions(tokens, text)));
+			(tokenRevision, tokens, text) -> post(() -> {
+				if (tokenRevision == revision) {
+					provideCompletions(tokens, text);
+				}
+			}));
 	private final Runnable updateRunnable = new Runnable() {
 		@Override
 		public void run() {
@@ -107,7 +111,6 @@ public class ShaderEditor extends LineNumberEditText {
 	private int tabWidthInCharacters = 0;
 	private int tabWidth = 0;
 	private List<Token> tokens = new ArrayList<>();
-	private int revision = 0;
 	private boolean isApplyingEdit = false;
 
 	public ShaderEditor(Context context) {
@@ -374,12 +377,13 @@ public class ShaderEditor extends LineNumberEditText {
 	protected void onSelectionChanged(int selStart, int selEnd) {
 		super.onSelectionChanged(selStart, selEnd);
 		Editable text = getText();
+		List<Token> completedTokens;
 		if (text != null &&
 				codeCompletionListener != null &&
 				getSelectionStart() == getSelectionEnd() &&
 				!isApplyingEdit &&
-				tokenListUpdater.isDone()) {
-			provideCompletions(tokens, text);
+				(completedTokens = tokenListUpdater.getCompletedTokens(revision)) != null) {
+			provideCompletions(completedTokens, text);
 		}
 	}
 
@@ -593,7 +597,10 @@ public class ShaderEditor extends LineNumberEditText {
 		}
 		int start = getSelectionStart();
 		Token tok = Lexer.findToken(tokens, start);
-		if (tok == null || tok.endOffset() >= text.length()) {
+		if (tok == null && start > 0) {
+			tok = Lexer.findToken(tokens, start - 1);
+		}
+		if (tok == null) {
 			listener.onCodeCompletions(DEFAULT_COMPLETIONS, 0);
 			return;
 		}
@@ -731,7 +738,7 @@ public class ShaderEditor extends LineNumberEditText {
 
 	@FunctionalInterface
 	interface OnTokenized {
-		void onTokens(@NonNull List<Token> tokens, @NonNull CharSequence text);
+		void onTokens(int revision, @NonNull List<Token> tokens, @NonNull CharSequence text);
 	}
 
 	private static class TabWidthSpan
@@ -781,12 +788,15 @@ public class ShaderEditor extends LineNumberEditText {
 
 	static class TokenizeCalculation implements Callable<List<Token>> {
 		private final String text;
+		private final int revision;
 		@NonNull
 		private final OnTokenized onTokenized;
 
 		public TokenizeCalculation(
+				int revision,
 				@NonNull String text,
 				@NonNull OnTokenized onTokenized) {
+			this.revision = revision;
 			this.text = text;
 			this.onTokenized = onTokenized;
 		}
@@ -801,7 +811,7 @@ public class ShaderEditor extends LineNumberEditText {
 					break;
 				}
 			}
-			onTokenized.onTokens(tokens, text);
+			onTokenized.onTokens(revision, tokens, text);
 			return tokens;
 		}
 	}
@@ -813,48 +823,69 @@ public class ShaderEditor extends LineNumberEditText {
 		private final ExecutorService executor = Executors.newSingleThreadExecutor();
 		@Nullable
 		private FutureTask<List<Token>> task;
+		@NonNull
+		private List<Token> completedTokens = Collections.emptyList();
 		private int revision = -1;
+		private int completedRevision = -1;
 
 		public TokenListUpdater(@NonNull OnTokenized onTokenized) {
 			this.onTokenized = onTokenized;
 		}
 
+		@Nullable
+		public synchronized List<Token> getCompletedTokens(int revision) {
+			return revision == completedRevision ? completedTokens : null;
+		}
+
+		private synchronized void setCompleted(int revision, @NonNull List<Token> tokens) {
+			if (revision != this.revision) {
+				return;
+			}
+			completedRevision = revision;
+			completedTokens = tokens;
+		}
+
 		@NonNull
 		public List<Token> ensureUpdated(@NonNull CharSequence text, int revision) {
-			if (task != null && revision == this.revision) {
-				try {
-					return task.get();
-				} catch (ExecutionException | InterruptedException e) {
-					throw new RuntimeException(e);
+			FutureTask<List<Token>> futureTask;
+			synchronized (this) {
+				if (task == null || revision != this.revision) {
+					update(text, revision);
 				}
+				futureTask = task;
 			}
-			update(text, revision);
-			FutureTask<List<Token>> futureTask = task;
 			if (futureTask == null) {
 				return Collections.emptyList();
 			}
 			try {
-				return futureTask.get();
+				List<Token> tokens = futureTask.get();
+				setCompleted(revision, tokens);
+				return tokens;
 			} catch (ExecutionException | InterruptedException e) {
 				throw new RuntimeException(e);
 			}
 		}
 
 		public void update(@NonNull CharSequence text, int revision) {
-			if (revision == this.revision && task != null) {
-				return;
-			} else if (task != null) {
-				task.cancel(false);
+			FutureTask<List<Token>> currentTask;
+			synchronized (this) {
+				if (revision == this.revision && task != null) {
+					return;
+				}
+				currentTask = task;
+				this.revision = revision;
+				task = new FutureTask<>(new TokenizeCalculation(
+						revision,
+						text.toString(),
+						(tokenRevision, tokens, tokenText) -> {
+							setCompleted(tokenRevision, tokens);
+							onTokenized.onTokens(tokenRevision, tokens, tokenText);
+						}));
 			}
-
-			this.revision = revision;
-			task = new FutureTask<>(new TokenizeCalculation(
-					text.toString(), onTokenized));
+			if (currentTask != null) {
+				currentTask.cancel(false);
+			}
 			executor.submit(task);
-		}
-
-		public boolean isDone() {
-			return task != null && task.isDone();
 		}
 
 		public void shutdown() {


### PR DESCRIPTION
## Summary
This change makes lexical completion deterministic again in the editor. Completion chips now come from the current revision only, end-of-buffer keyword completion behaves correctly, and tapping a visible chip still inserts only the intended suffix.

## Why
The completion pipeline previously had two correctness gaps: end-of-buffer token lookup could miss valid keyword completions, and async completion publication could show stale results or apply an insertion offset that no longer matched the visible chip list. That made completion behavior feel unreliable during normal typing.

## What Changed
- Scoped selection-driven completion reads to the completed token snapshot for the current editor revision.
- Kept completion list publication and suffix insertion offset in the same committed state so visible chips and insert behavior stay aligned.
- Preserved lexical suffix-only insertion while fixing EOF token lookup behavior.

## Validation
- `./gradlew :app:compileDebugJavaWithJavac`
- `./gradlew installDebug`
- Manual Android verification: `ret` -> `return` at EOF, chip tap inserts only `urn`, and rapid `ret` -> `whi` settles on `while` rather than an older completion.

## Risk
Scope is limited to the editor completion path and extra-keys publication boundary. The main regression surface is stale lexical completion state around rapid edits or caret moves.