### PR TITLE
Make Shader Diagnostic Mapping Explicit

### DIFF
--- a/app/src/main/java/de/markusfisch/android/shadereditor/opengl/GlDevice.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/opengl/GlDevice.java
@@ -286,11 +286,11 @@ final class GlDevice {
 	GlProgramBuildResult createProgram(
 			@NonNull String vertexSource,
 			@NonNull String fragmentSource,
-			int fragmentExtraLines) {
+			@NonNull ShaderLineMapping fragmentLineMapping) {
 		ShaderCompileResult vertexCompile = compileShader(
 				GLES20.GL_VERTEX_SHADER,
 				vertexSource,
-				0);
+				ShaderLineMapping.identity());
 		if (vertexCompile.shader == null) {
 			return GlProgramBuildResult.failure(vertexCompile.infoLog);
 		}
@@ -298,7 +298,7 @@ final class GlDevice {
 		ShaderCompileResult fragmentCompile = compileShader(
 				GLES20.GL_FRAGMENT_SHADER,
 				fragmentSource,
-				fragmentExtraLines);
+				fragmentLineMapping);
 		if (fragmentCompile.shader == null) {
 			deleteShader(vertexCompile.shader);
 			return GlProgramBuildResult.failure(fragmentCompile.infoLog);
@@ -324,7 +324,7 @@ final class GlDevice {
 		if (linkStatus[0] != GLES20.GL_TRUE) {
 			List<ShaderError> infoLog = ShaderError.parseAll(
 					GLES20.glGetProgramInfoLog(programId),
-					fragmentExtraLines);
+					fragmentLineMapping);
 			GLES20.glDeleteProgram(programId);
 			return GlProgramBuildResult.failure(infoLog);
 		}
@@ -522,7 +522,7 @@ final class GlDevice {
 	@Nullable
 	private ShaderCompileResult compileShader(int type,
 			@NonNull String source,
-			int extraLines) {
+			@NonNull ShaderLineMapping lineMapping) {
 		int shaderId = GLES20.glCreateShader(type);
 		if (shaderId == 0) {
 			return new ShaderCompileResult(
@@ -538,7 +538,7 @@ final class GlDevice {
 		if (compiled[0] == 0) {
 			List<ShaderError> infoLog = ShaderError.parseAll(
 					GLES20.glGetShaderInfoLog(shaderId),
-					extraLines);
+					lineMapping);
 			GLES20.glDeleteShader(shaderId);
 			return new ShaderCompileResult(null, infoLog);
 		}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/opengl/GpuBitmapTransformer.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/opengl/GpuBitmapTransformer.java
@@ -306,7 +306,7 @@ public final class GpuBitmapTransformer {
 			GlProgramBuildResult result = device.createProgram(
 					VERTEX_SHADER,
 					FRAGMENT_SHADER,
-					0);
+					ShaderLineMapping.identity());
 			if (!result.succeeded() || result.getProgram() == null) {
 				List<ShaderError> log = result.getInfoLog();
 				throw new IllegalStateException(

--- a/app/src/main/java/de/markusfisch/android/shadereditor/opengl/PreparedShaderInput.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/opengl/PreparedShaderInput.java
@@ -1,0 +1,27 @@
+package de.markusfisch.android.shadereditor.opengl;
+
+import androidx.annotation.NonNull;
+
+final class PreparedShaderInput {
+	@NonNull
+	private final String source;
+	@NonNull
+	private final ShaderLineMapping lineMapping;
+
+	PreparedShaderInput(
+			@NonNull String source,
+			@NonNull ShaderLineMapping lineMapping) {
+		this.source = source;
+		this.lineMapping = lineMapping;
+	}
+
+	@NonNull
+	String getSource() {
+		return source;
+	}
+
+	@NonNull
+	ShaderLineMapping getLineMapping() {
+		return lineMapping;
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/opengl/PreparedShaderSource.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/opengl/PreparedShaderSource.java
@@ -7,9 +7,8 @@ import java.util.List;
 
 final class PreparedShaderSource {
 	@Nullable
-	private final String fragmentShader;
+	private final PreparedShaderInput fragmentShader;
 	private final float fTimeMax;
-	private final int fragmentShaderExtraLines;
 	@Nullable
 	private final String gles3VersionDirective;
 	@NonNull
@@ -18,15 +17,13 @@ final class PreparedShaderSource {
 	private final List<DiscoveredSampler> samplers;
 
 	PreparedShaderSource(
-			@Nullable String fragmentShader,
+			@Nullable PreparedShaderInput fragmentShader,
 			float fTimeMax,
-			int fragmentShaderExtraLines,
 			@Nullable String gles3VersionDirective,
 			@NonNull BackBufferParameters backBufferParameters,
 			@NonNull List<DiscoveredSampler> samplers) {
 		this.fragmentShader = fragmentShader;
 		this.fTimeMax = fTimeMax;
-		this.fragmentShaderExtraLines = fragmentShaderExtraLines;
 		this.gles3VersionDirective = gles3VersionDirective;
 		this.backBufferParameters = backBufferParameters;
 		this.samplers = List.copyOf(samplers);
@@ -37,23 +34,18 @@ final class PreparedShaderSource {
 		return new PreparedShaderSource(
 				null,
 				3f,
-				0,
 				null,
 				new BackBufferParameters(),
 				List.of());
 	}
 
 	@Nullable
-	String getFragmentShader() {
+	PreparedShaderInput getFragmentShader() {
 		return fragmentShader;
 	}
 
 	float getFTimeMax() {
 		return fTimeMax;
-	}
-
-	int getFragmentShaderExtraLines() {
-		return fragmentShaderExtraLines;
 	}
 
 	@NonNull

--- a/app/src/main/java/de/markusfisch/android/shadereditor/opengl/RendererProgramManager.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/opengl/RendererProgramManager.java
@@ -87,7 +87,7 @@ final class RendererProgramManager {
 
 	boolean hasPreparedShader() {
 		var fragmentShader = preparedShaderSource.getFragmentShader();
-		return fragmentShader != null && !fragmentShader.isEmpty();
+		return fragmentShader != null && !fragmentShader.getSource().isEmpty();
 	}
 
 	@NonNull
@@ -98,7 +98,7 @@ final class RendererProgramManager {
 		var surfaceResult = device.createProgram(
 				FULL_SCREEN_VERTEX_SHADER,
 				SURFACE_FRAGMENT_SHADER,
-				0);
+				ShaderLineMapping.identity());
 		if (!surfaceResult.succeeded() || surfaceResult.getProgram() == null) {
 			return ReloadResult.failure(textureErrors, surfaceResult.getInfoLog());
 		}
@@ -114,8 +114,8 @@ final class RendererProgramManager {
 						FULL_SCREEN_VERTEX_SHADER,
 						FULL_SCREEN_VERTEX_SHADER_3,
 						version),
-				fragmentShader,
-				preparedShaderSource.getFragmentShaderExtraLines());
+				fragmentShader.getSource(),
+				fragmentShader.getLineMapping());
 		if (!mainResult.succeeded() || mainResult.getProgram() == null) {
 			device.deleteProgram(surfaceResult.getProgram());
 			return ReloadResult.failure(textureErrors, mainResult.getInfoLog());

--- a/app/src/main/java/de/markusfisch/android/shadereditor/opengl/ShaderError.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/opengl/ShaderError.java
@@ -50,10 +50,19 @@ public class ShaderError {
 	public static List<ShaderError> parseAll(
 			@NonNull String infoLog,
 			int silentlyAddedExtraLines) {
+		return parseAll(
+				infoLog,
+				ShaderLineMapping.withLeadingInsertedLines(silentlyAddedExtraLines));
+	}
+
+	@NonNull
+	static List<ShaderError> parseAll(
+			@NonNull String infoLog,
+			@NonNull ShaderLineMapping lineMapping) {
 		String[] messages = infoLog.split("\n");
 		List<ShaderError> shaderErrors = new ArrayList<>(messages.length);
 		for (String message : messages) {
-			shaderErrors.add(parse(message, silentlyAddedExtraLines));
+			shaderErrors.add(parse(message, lineMapping));
 		}
 		return shaderErrors;
 	}
@@ -67,6 +76,15 @@ public class ShaderError {
 	public static ShaderError parse(
 			@NonNull String message,
 			int silentlyAddedExtraLines) {
+		return parse(
+				message,
+				ShaderLineMapping.withLeadingInsertedLines(silentlyAddedExtraLines));
+	}
+
+	@NonNull
+	static ShaderError parse(
+			@NonNull String message,
+			@NonNull ShaderLineMapping lineMapping) {
 		Matcher matcher = ERROR_PATTERN.matcher(message);
 		if (!matcher.matches()) {
 			return ShaderError.createGeneral(message);
@@ -80,9 +98,8 @@ public class ShaderError {
 		if (errorLineString == null) {
 			return ShaderError.createGeneral(message);
 		}
-		int errorLine = Math.max(
-				Integer.parseInt(errorLineString) - silentlyAddedExtraLines,
-				-1);
+		int errorLine = lineMapping.toSourceLine(
+				Integer.parseInt(errorLineString));
 		String infoLog = Objects.requireNonNull(matcher.group(3));
 		return new ShaderError(sourceStringNumber, errorLine, infoLog);
 	}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/opengl/ShaderLineMapping.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/opengl/ShaderLineMapping.java
@@ -1,0 +1,80 @@
+package de.markusfisch.android.shadereditor.opengl;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class ShaderLineMapping {
+	private static final ShaderLineMapping IDENTITY =
+			new ShaderLineMapping(List.of());
+
+	@NonNull
+	private final List<InsertedLines> insertions;
+
+	private ShaderLineMapping(@NonNull List<InsertedLines> insertions) {
+		this.insertions = List.copyOf(insertions);
+	}
+
+	@NonNull
+	static ShaderLineMapping identity() {
+		return IDENTITY;
+	}
+
+	@NonNull
+	static ShaderLineMapping withLeadingInsertedLines(int lineCount) {
+		return identity().addInsertedLinesAfterSourceLine(0, lineCount);
+	}
+
+	int toSourceLine(int preparedLine) {
+		if (preparedLine < 1) {
+			return -1;
+		}
+
+		int removedLines = 0;
+		for (InsertedLines insertion : insertions) {
+			int startLine = insertion.sourceLine + removedLines + 1;
+			int endLine = startLine + insertion.lineCount - 1;
+			if (preparedLine < startLine) {
+				break;
+			}
+			if (preparedLine <= endLine) {
+				return -1;
+			}
+			removedLines += insertion.lineCount;
+		}
+
+		return Math.max(preparedLine - removedLines, -1);
+	}
+
+	@NonNull
+	ShaderLineMapping addInsertedLinesAfterSourceLine(int sourceLine, int lineCount) {
+		if (lineCount <= 0) {
+			return this;
+		}
+
+		ArrayList<InsertedLines> updatedInsertions = new ArrayList<>(insertions);
+		int last = updatedInsertions.size() - 1;
+		if (last >= 0) {
+			InsertedLines previous = updatedInsertions.get(last);
+			if (previous.sourceLine == sourceLine) {
+				updatedInsertions.set(last, new InsertedLines(
+						sourceLine,
+						previous.lineCount + lineCount));
+				return new ShaderLineMapping(updatedInsertions);
+			}
+		}
+		updatedInsertions.add(new InsertedLines(sourceLine, lineCount));
+		return new ShaderLineMapping(updatedInsertions);
+	}
+
+	private static final class InsertedLines {
+		private final int sourceLine;
+		private final int lineCount;
+
+		private InsertedLines(int sourceLine, int lineCount) {
+			this.sourceLine = sourceLine;
+			this.lineCount = lineCount;
+		}
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/opengl/ShaderSourcePreparer.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/opengl/ShaderSourcePreparer.java
@@ -51,15 +51,15 @@ final class ShaderSourcePreparer {
 			return new PreparedShaderSource(
 					null,
 					fTimeMax,
-					0,
 					null,
 					new BackBufferParameters(),
 					List.of());
 		}
 
 		String gles3Version = getGLES3Version(source, version);
-		String preparedSource = source;
-		int fragmentShaderExtraLines = 0;
+		PreparedShaderInput preparedInput = new PreparedShaderInput(
+				source,
+				ShaderLineMapping.identity());
 		BackBufferParameters backBufferParameters = new BackBufferParameters();
 		ArrayList<DiscoveredSampler> samplers = new ArrayList<>();
 
@@ -85,11 +85,8 @@ final class ShaderSourcePreparer {
 					String pattern = gles3Version != null
 							? OES_EXTERNAL_ESS3
 							: OES_EXTERNAL;
-					if (!preparedSource.contains(pattern)) {
-						preparedSource = addPreprocessorDirective(
-								preparedSource,
-								pattern);
-						++fragmentShaderExtraLines;
+					if (!preparedInput.getSource().contains(pattern)) {
+						preparedInput = addPreprocessorDirective(preparedInput, pattern);
 					}
 					yield GLES11Ext.GL_TEXTURE_EXTERNAL_OES;
 				}
@@ -105,17 +102,13 @@ final class ShaderSourcePreparer {
 					new TextureParameters(params)));
 		}
 
-		if (!preparedSource.contains(SHADER_EDITOR)) {
-			preparedSource = addPreprocessorDirective(
-					preparedSource,
-					SHADER_EDITOR);
-			++fragmentShaderExtraLines;
+		if (!preparedInput.getSource().contains(SHADER_EDITOR)) {
+			preparedInput = addPreprocessorDirective(preparedInput, SHADER_EDITOR);
 		}
 
 		return new PreparedShaderSource(
-				preparedSource,
+				preparedInput,
 				fTimeMax,
-				fragmentShaderExtraLines,
 				gles3Version,
 				backBufferParameters,
 				samplers);
@@ -141,19 +134,49 @@ final class ShaderSourcePreparer {
 	}
 
 	@NonNull
-	private static String addPreprocessorDirective(
-			@NonNull String source,
+	private static PreparedShaderInput addPreprocessorDirective(
+			@NonNull PreparedShaderInput input,
 			@NonNull String directive) {
+		String source = input.getSource();
+		ShaderLineMapping lineMapping = input.getLineMapping();
+		int insertedLines = countLines(directive);
 		if (source.trim().startsWith("#version")) {
 			int lineFeed = source.indexOf("\n");
 			if (lineFeed < 0) {
-				return source;
+				return input;
 			}
+			int sourceLine = countSourceLines(source, lineFeed + 1);
 			++lineFeed;
-			return source.substring(0, lineFeed) +
-					directive +
-					source.substring(lineFeed);
+			return new PreparedShaderInput(
+					source.substring(0, lineFeed) +
+							directive +
+							source.substring(lineFeed),
+					lineMapping.addInsertedLinesAfterSourceLine(
+							sourceLine,
+							insertedLines));
 		}
-		return directive + source;
+		return new PreparedShaderInput(
+				directive + source,
+				lineMapping.addInsertedLinesAfterSourceLine(0, insertedLines));
+	}
+
+	private static int countSourceLines(@NonNull String source, int endExclusive) {
+		int lines = 0;
+		for (int index = 0; index < endExclusive; ++index) {
+			if (source.charAt(index) == '\n') {
+				++lines;
+			}
+		}
+		return lines;
+	}
+
+	private static int countLines(@NonNull String source) {
+		int lines = 1;
+		for (int index = 0; index < source.length(); ++index) {
+			if (source.charAt(index) == '\n') {
+				++lines;
+			}
+		}
+		return source.endsWith("\n") ? lines - 1 : lines;
 	}
 }


### PR DESCRIPTION
## Summary
This change makes fragment shader diagnostic remapping explicit by carrying prepared source text and line mapping together through the compile pipeline. Maintainers now have a single preparation path for fragment shaders, and injected directives continue to map compiler errors back to the editor's source lines.

## Why
The previous implementation relied on a flat extra-line offset, which was fragile and too implicit for future compile-input transformations. Making the mapping a dedicated model keeps preparation and remapping coupled so diagnostics stay correct as the pipeline evolves.

## What Changed
- Added `PreparedShaderInput` to represent prepared fragment source together with its line mapping.
- Added `ShaderLineMapping` and used it to remap diagnostics instead of subtracting a flat extra-line count.
- Wired `ShaderSourcePreparer`, `RendererProgramManager`, `GlDevice`, and `ShaderError` through the explicit compile-input model.

## Validation
- `./gradlew :app:compileDebugJavaWithJavac`
- Temporary package-scoped Java smoke test  for `#version` and top-of-file directive insertions

## Risk
The change is localized to fragment shader preparation and diagnostic parsing, so the main regression surface is compiler error remapping around injected directives. More complex future source transformations still need richer mapping coverage than the current inserted-lines model.