### PR TITLE
Coalesce overlapping shader drawer reloads

### DIFF
--- a/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/CoalescingReloadGate.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/CoalescingReloadGate.java
@@ -1,0 +1,29 @@
+package de.markusfisch.android.shadereditor.activity.managers;
+
+final class CoalescingReloadGate {
+	private boolean loading = false;
+	private boolean reloadQueued = false;
+
+	public synchronized boolean request() {
+		if (loading) {
+			reloadQueued = true;
+			return false;
+		}
+		loading = true;
+		return true;
+	}
+
+	public synchronized boolean finish() {
+		if (reloadQueued) {
+			reloadQueued = false;
+			return true;
+		}
+		loading = false;
+		return false;
+	}
+
+	public synchronized void abort() {
+		loading = false;
+		reloadQueued = false;
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/ShaderListManager.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/ShaderListManager.java
@@ -11,11 +11,11 @@ import androidx.annotation.NonNull;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 
 import de.markusfisch.android.shadereditor.R;
 import de.markusfisch.android.shadereditor.adapter.ShaderAdapter;
@@ -43,6 +43,7 @@ public class ShaderListManager {
 	// Use an ExecutorService for background tasks and a Handler for the main thread.
 	private final ExecutorService executor = Executors.newSingleThreadExecutor();
 	private final Handler handler = new Handler(Looper.getMainLooper());
+	private final CoalescingReloadGate reloadGate = new CoalescingReloadGate();
 
 	public ShaderListManager(@NonNull Activity activity,
 			@NonNull ListView listView,
@@ -72,36 +73,11 @@ public class ShaderListManager {
 	 * Loads shaders from the database asynchronously.
 	 */
 	public void loadShadersAsync() {
-		if (executor.isShutdown()) {
+		if (executor.isShutdown() ||
+				!reloadGate.request()) {
 			return;
 		}
-		// Use a WeakReference to avoid leaking the context if the activity
-		// is destroyed.
-		WeakReference<ShaderListManager> managerRef = new WeakReference<>(this);
-
-		executor.execute(() -> {
-			ShaderListManager manager = managerRef.get();
-			if (manager == null) {
-				return;
-			}
-
-			// Perform the long-running database query on a background thread.
-			List<ShaderInfo> shaders = manager.dataSource.shader.getShaders(
-					ShaderEditorApp.preferences.sortByLastModification());
-
-			// Post the result back to the main thread.
-			manager.handler.post(() -> {
-				ShaderListManager finalManager = managerRef.get();
-				// Ensure the manager and its activity are still valid.
-				if (finalManager != null && !finalManager.activity.isFinishing()) {
-					List<ShaderInfo> shaderList = shaders != null
-							? shaders
-							: new ArrayList<>();
-					finalManager.listener.onShadersLoaded(shaderList);
-					finalManager.updateAdapter(shaderList);
-				}
-			});
-		});
+		submitLoad();
 	}
 
 	public void destroy() {
@@ -109,9 +85,43 @@ public class ShaderListManager {
 		handler.removeCallbacksAndMessages(null);
 	}
 
+	private void submitLoad() {
+		try {
+			executor.execute(() -> {
+				List<ShaderInfo> shaders = dataSource.shader.getShaders(
+						ShaderEditorApp.preferences.sortByLastModification());
+				handler.post(() -> onShadersLoaded(shaders));
+			});
+		} catch (RejectedExecutionException ignored) {
+			reloadGate.abort();
+		}
+	}
+
+	private void onShadersLoaded(List<ShaderInfo> shaders) {
+		if (reloadGate.finish()) {
+			if (!executor.isShutdown() && isActivityAlive()) {
+				submitLoad();
+			} else {
+				reloadGate.abort();
+			}
+			return;
+		}
+		if (!isActivityAlive()) {
+			return;
+		}
+		List<ShaderInfo> shaderList = shaders != null
+				? shaders
+				: new ArrayList<>();
+		listener.onShadersLoaded(shaderList);
+		updateAdapter(shaderList);
+	}
+
+	private boolean isActivityAlive() {
+		return !activity.isFinishing() && !activity.isDestroyed();
+	}
+
 	private void updateAdapter(List<ShaderInfo> shaders) {
-		// The isFinishing() check is already here, making it robust.
-		if (activity.isFinishing()) {
+		if (!isActivityAlive()) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
Shader drawer reloads now collapse overlapping refresh bursts into latest-only work. While one shader-list query is running, new reload requests keep only one follow-up query for the newest requested state, so outdated results no longer churn the drawer.

## Why
Saving or switching shaders can still trigger multiple full shader-list reloads back-to-back. Only the newest reload matters, but every intermediate request still queues database work and adapter refreshes.

## What Changed
- Added `CoalescingReloadGate` to track one in-flight shader-list load plus at most one queued follow-up reload.
- Routed `ShaderListManager.loadShadersAsync()` through the gate so stale results never reach `onShadersLoaded()` or `updateAdapter()`.
- Kept implementation to a small boolean drain model (`loading` + `reloadQueued`).

<details>
<summary>Reload flow</summary>

```mermaid
sequenceDiagram
	participant UI as UI thread
	participant Gate as CoalescingReloadGate
	participant BG as DB executor

	UI->>Gate: request()
	Gate-->>UI: start load
	UI->>BG: query shaders

	UI->>Gate: request() during load
	Gate-->>UI: queue follow-up only
	UI->>Gate: request() during load
	Gate-->>UI: keep single queued follow-up

	BG-->>UI: first result
	UI->>Gate: finish()
	Gate-->>UI: run one follow-up load
	UI->>BG: query shaders again

	UI->>Gate: request() during follow-up
	Gate-->>UI: queue next follow-up only

	BG-->>UI: second result
	UI->>Gate: finish()
	Gate-->>UI: run one more follow-up load

	BG-->>UI: final result
	UI->>Gate: finish()
	Gate-->>UI: deliver latest result
```

</details>

## Validation
- `./gradlew :app:compileDebugJavaWithJavac`
- Manual Android verification: create a new shader, open the drawer, switch back to `Default`, reopen the drawer, and confirm both shader titles still render after the coalesced reload path drains.

## Risk
Scope stays local to shader drawer reload scheduling. Rename/delete database work and thumbnail decode still use their current paths, so this reduces redundant reload churn but does not yet address every remaining drawer cost.
