### PR TITLE
feat(project): add project session model

### DIFF
--- a/app/src/main/java/de/markusfisch/android/shadereditor/activity/MainActivity.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/activity/MainActivity.java
@@ -126,7 +126,8 @@ public class MainActivity extends AppCompatActivity {
 					editorFragment.clearError();
 					editorFragment.highlightErrors();
 				}
-				shaderViewManager.setFragmentShader(text);
+				shaderViewManager.setProjectSession(
+						shaderManager.getEditedProjectSession(text));
 			}
 		});
 		editorFragment.setOnTextModifiedListener(() -> shaderManager.setModified(true));
@@ -486,15 +487,17 @@ public class MainActivity extends AppCompatActivity {
 
 	private void runShader() {
 		String src = editorFragment.getText();
+		var projectSession = shaderManager.getEditedProjectSession(src);
 		editorFragment.clearError();
 		if (ShaderEditorApp.preferences.doesSaveOnRun()) {
 			PreviewActivity.renderStatus.reset();
 			shaderManager.saveShader();
+			projectSession = shaderManager.getEditedProjectSession(src);
 		}
 		if (ShaderEditorApp.preferences.doesRunInBackground()) {
-			shaderViewManager.setFragmentShader(src);
+			shaderViewManager.setProjectSession(projectSession);
 		} else {
-			navigationManager.showPreview(src, shaderManager.getQuality(),
+			navigationManager.showPreview(projectSession,
 					shaderManager.previewShaderLauncher);
 		}
 	}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/activity/PreviewActivity.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/activity/PreviewActivity.java
@@ -1,16 +1,21 @@
 package de.markusfisch.android.shadereditor.activity;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import java.io.Serializable;
 import java.util.List;
 
 import de.markusfisch.android.shadereditor.opengl.ShaderError;
 import de.markusfisch.android.shadereditor.opengl.ShaderRenderer;
+import de.markusfisch.android.shadereditor.project.LooseShaderFileProjectSource;
+import de.markusfisch.android.shadereditor.project.ShaderProjectSession;
 import de.markusfisch.android.shadereditor.widget.ShaderView;
 
 public class PreviewActivity extends AppCompatActivity {
@@ -47,6 +52,7 @@ public class PreviewActivity extends AppCompatActivity {
 	}
 
 	public static final String FRAGMENT_SHADER = "fragment_shader";
+	public static final String PROJECT_SESSION = "project_session";
 	public static final String QUALITY = "quality";
 	public static final RenderStatus renderStatus = new RenderStatus();
 
@@ -133,19 +139,51 @@ public class PreviewActivity extends AppCompatActivity {
 	}
 
 	private boolean setShaderFromIntent(Intent intent) {
-		String fragmentShader;
-
-		if (intent == null ||
-				shaderView == null ||
-				(fragmentShader = intent.getStringExtra(
-						FRAGMENT_SHADER)) == null) {
+		ShaderProjectSession projectSession = getProjectSession(intent);
+		if (shaderView == null || projectSession == null) {
 			return false;
 		}
 
 		shaderView.setFragmentShader(
-				fragmentShader,
-				intent.getFloatExtra(QUALITY, 1f));
-
+				projectSession.getEntryPointSource(),
+				projectSession.getQuality());
 		return true;
+	}
+
+	@Nullable
+	private static ShaderProjectSession getProjectSession(Intent intent) {
+		if (intent == null) {
+			return null;
+		}
+
+		ShaderProjectSession projectSession = getSerializedProjectSession(intent);
+		if (projectSession != null) {
+			return projectSession;
+		}
+
+		String fragmentShader = intent.getStringExtra(FRAGMENT_SHADER);
+		if (fragmentShader == null) {
+			return null;
+		}
+
+		return new LooseShaderFileProjectSource(
+				null,
+				fragmentShader,
+				intent.getFloatExtra(QUALITY, 1f)).openSession();
+	}
+
+	@Nullable
+	private static ShaderProjectSession getSerializedProjectSession(
+			@NonNull Intent intent) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+			return intent.getSerializableExtra(
+					PROJECT_SESSION,
+					ShaderProjectSession.class);
+		}
+		@SuppressWarnings("deprecation")
+		Serializable extra = intent.getSerializableExtra(PROJECT_SESSION);
+		return extra instanceof ShaderProjectSession
+				? (ShaderProjectSession) extra
+				: null;
 	}
 }

--- a/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/NavigationManager.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/NavigationManager.java
@@ -16,6 +16,7 @@ import de.markusfisch.android.shadereditor.activity.LoadSampleActivity;
 import de.markusfisch.android.shadereditor.activity.PreferencesActivity;
 import de.markusfisch.android.shadereditor.activity.PreviewActivity;
 import de.markusfisch.android.shadereditor.app.ShaderEditorApp;
+import de.markusfisch.android.shadereditor.project.ShaderProjectSession;
 
 public class NavigationManager {
 	@NonNull
@@ -42,11 +43,11 @@ public class NavigationManager {
 				"https://github.com/markusfisch/ShaderEditor/blob/master/FAQ.md")));
 	}
 
-	public void showPreview(String src, float quality,
+	public void showPreview(@NonNull ShaderProjectSession projectSession,
 			ActivityResultLauncher<Intent> launcher) {
 		Intent intent = new Intent(activity, PreviewActivity.class);
-		intent.putExtra(PreviewActivity.QUALITY, quality);
-		intent.putExtra(PreviewActivity.FRAGMENT_SHADER, src);
+		intent.putExtra(PreviewActivity.QUALITY, projectSession.getQuality());
+		intent.putExtra(PreviewActivity.PROJECT_SESSION, projectSession);
 
 		if (ShaderEditorApp.preferences.doesRunInNewTask() &&
 				Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {

--- a/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/ShaderManager.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/ShaderManager.java
@@ -24,6 +24,9 @@ import de.markusfisch.android.shadereditor.activity.PreviewActivity;
 import de.markusfisch.android.shadereditor.app.ShaderEditorApp;
 import de.markusfisch.android.shadereditor.database.DataSource;
 import de.markusfisch.android.shadereditor.fragment.EditorFragment;
+import de.markusfisch.android.shadereditor.project.LegacyShaderProjectSource;
+import de.markusfisch.android.shadereditor.project.LooseShaderFileProjectSource;
+import de.markusfisch.android.shadereditor.project.ShaderProjectSession;
 
 public class ShaderManager {
 	public final ActivityResultLauncher<Intent> addUniformLauncher;
@@ -43,6 +46,8 @@ public class ShaderManager {
 	private long selectedShaderId = NO_SHADER;
 	private float quality = 1f;
 	private boolean isModified = false;
+	@Nullable
+	private ShaderProjectSession currentProjectSession;
 
 	public ShaderManager(@NonNull AppCompatActivity activity,
 			EditorFragment editorFragment,
@@ -119,6 +124,9 @@ public class ShaderManager {
 
 	public void setQuality(float quality) {
 		this.quality = quality;
+		if (currentProjectSession != null) {
+			currentProjectSession = currentProjectSession.withQuality(quality);
+		}
 		setModified(true);
 	}
 
@@ -144,6 +152,19 @@ public class ShaderManager {
 				SELECTED_SHADER_ID, NO_SHADER);
 	}
 
+	@NonNull
+	public ShaderProjectSession getEditedProjectSession() {
+		return getEditedProjectSession(editorFragment.getText());
+	}
+
+	@NonNull
+	public ShaderProjectSession getEditedProjectSession(
+			@NonNull String entryPointSource) {
+		return getCurrentProjectSession()
+				.withEntryPointSource(entryPointSource)
+				.withQuality(quality);
+	}
+
 	public void selectShader(long id) {
 		if (isModified()) {
 			saveShader();
@@ -151,31 +172,22 @@ public class ShaderManager {
 
 		PreviewActivity.renderStatus.reset();
 		var shader = dataSource.shader.getShader(id);
-
 		if (shader == null) {
-			selectedShaderId = NO_SHADER;
-			editorFragment.setText(activity.getString(
-					R.string.new_shader_template));
-			uiManager.setToolbarTitle(activity.getString(R.string.add_shader));
-			quality = 1f;
-		} else {
-			selectedShaderId = id;
-			ShaderEditorApp.preferences.setLastOpenedShader(id);
-			editorFragment.setText(shader.fragmentShader());
-			uiManager.setToolbarTitle(shader.getTitle());
-			quality = shader.quality();
+			applyProjectSession(
+					NO_SHADER,
+					createScratchProjectSession(
+							activity.getString(R.string.new_shader_template),
+							1f),
+					activity.getString(R.string.add_shader));
+			return;
 		}
 
-		ShaderEditorApp.preferences.setPendingCrashShaderId(
-				ShaderEditorApp.preferences.doesRunInBackground() &&
-						selectedShaderId > 0
-						? selectedShaderId
-						: 0);
-
-		shaderListManager.setSelectedShaderId(selectedShaderId);
-		shaderViewManager.setQuality(quality);
-		shaderViewManager.setFragmentShader(editorFragment.getText());
-		setModified(false);
+		ShaderProjectSession projectSession =
+				new LegacyShaderProjectSource(shader).openSession();
+		ShaderEditorApp.preferences.setLastOpenedShader(id);
+		applyProjectSession(id,
+				projectSession,
+				projectSession.getProject().getTitle());
 	}
 
 	public void saveShader() {
@@ -193,7 +205,6 @@ public class ShaderManager {
 		}
 
 		byte[] thumbnail = getThumbnail();
-
 		if (selectedShaderId > 0) {
 			dataSource.shader.updateShader(
 					selectedShaderId, src, thumbnail, quality);
@@ -203,6 +214,8 @@ public class ShaderManager {
 			shaderListManager.setSelectedShaderId(selectedShaderId);
 		}
 
+		currentProjectSession = loadSavedProjectSession(selectedShaderId, src);
+		updatePendingCrashShaderId();
 		setModified(false);
 		shaderListManager.loadShadersAsync();
 		Toast.makeText(activity, R.string.shader_saved,
@@ -239,10 +252,14 @@ public class ShaderManager {
 			while ((len = in.read(buffer)) != -1) {
 				sb.append(new String(buffer, 0, len, StandardCharsets.UTF_8));
 			}
+			ShaderProjectSession projectSession =
+					new LooseShaderFileProjectSource(uri, sb.toString(), 1f)
+							.openSession();
 			PreviewActivity.renderStatus.reset();
 			intent.setAction(null);
-			selectShader(NO_SHADER);
-			editorFragment.setText(sb.toString());
+			applyProjectSession(NO_SHADER,
+					projectSession,
+					projectSession.getProject().getTitle());
 			setModified(true);
 		} catch (IOException e) {
 			Toast.makeText(activity, R.string.unsuitable_text,
@@ -267,6 +284,54 @@ public class ShaderManager {
 		dataSource.shader.removeShader(shaderId);
 		if (shaderId == selectedShaderId) {
 			selectedShaderId = NO_SHADER;
+			currentProjectSession = null;
+			updatePendingCrashShaderId();
 		}
+	}
+
+	@NonNull
+	private ShaderProjectSession getCurrentProjectSession() {
+		return currentProjectSession != null
+				? currentProjectSession
+				: createScratchProjectSession(editorFragment.getText(), quality);
+	}
+
+	@NonNull
+	private ShaderProjectSession createScratchProjectSession(
+			@NonNull String source,
+			float quality) {
+		return new LooseShaderFileProjectSource(null, source, quality)
+				.openSession();
+	}
+
+	@NonNull
+	private ShaderProjectSession loadSavedProjectSession(long shaderId,
+			@NonNull String fallbackSource) {
+		var shader = dataSource.shader.getShader(shaderId);
+		return shader != null
+				? new LegacyShaderProjectSource(shader).openSession()
+				: createScratchProjectSession(fallbackSource, quality);
+	}
+
+	private void applyProjectSession(long shaderId,
+			@NonNull ShaderProjectSession projectSession,
+			@NonNull String toolbarTitle) {
+		selectedShaderId = shaderId;
+		currentProjectSession = projectSession;
+		quality = projectSession.getQuality();
+		editorFragment.setText(projectSession.getEntryPointSource());
+		uiManager.setToolbarTitle(toolbarTitle);
+		shaderListManager.setSelectedShaderId(selectedShaderId);
+		shaderViewManager.setProjectSession(projectSession);
+		updatePendingCrashShaderId();
+		setModified(false);
+	}
+
+	private void updatePendingCrashShaderId() {
+		ShaderEditorApp.preferences.setPendingCrashShaderId(
+				ShaderEditorApp.preferences.doesRunInBackground() &&
+						selectedShaderId > 0
+						? selectedShaderId
+						: 0);
 	}
 }

--- a/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/ShaderViewManager.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/activity/managers/ShaderViewManager.java
@@ -14,6 +14,7 @@ import java.util.List;
 import de.markusfisch.android.shadereditor.R;
 import de.markusfisch.android.shadereditor.opengl.ShaderError;
 import de.markusfisch.android.shadereditor.opengl.ShaderRenderer;
+import de.markusfisch.android.shadereditor.project.ShaderProjectSession;
 import de.markusfisch.android.shadereditor.widget.ShaderView;
 
 public class ShaderViewManager {
@@ -61,6 +62,13 @@ public class ShaderViewManager {
 
 	public void setFragmentShader(@Nullable String src) {
 		shaderView.setFragmentShader(src, quality);
+	}
+
+	public void setProjectSession(@NonNull ShaderProjectSession projectSession) {
+		setQuality(projectSession.getQuality());
+		shaderView.setFragmentShader(
+				projectSession.getEntryPointSource(),
+				projectSession.getQuality());
 	}
 
 	public void setVisibility(boolean visible) {

--- a/app/src/main/java/de/markusfisch/android/shadereditor/project/FolderShaderProjectSource.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/project/FolderShaderProjectSource.java
@@ -1,0 +1,78 @@
+package de.markusfisch.android.shadereditor.project;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+public final class FolderShaderProjectSource implements ShaderProjectSource {
+	@NonNull
+	private final String title;
+	@NonNull
+	private final String entryFilePath;
+	@NonNull
+	private final List<ShaderProjectFile> files;
+	private final float quality;
+	@NonNull
+	private final ShaderProjectOrigin origin;
+
+	public FolderShaderProjectSource(@Nullable Uri rootUri,
+			@Nullable String title,
+			@NonNull String entryFilePath,
+			@NonNull Collection<ShaderProjectFile> files,
+			float quality) {
+		this.title = getTitle(rootUri, title);
+		this.entryFilePath = ShaderProjectPaths.normalize(entryFilePath);
+		this.files = new ArrayList<>(Objects.requireNonNull(files));
+		this.quality = quality;
+		origin = new ShaderProjectOrigin(
+				ShaderProjectOrigin.Type.FOLDER,
+				rootUri != null ? rootUri.toString() : "folder:" + this.title,
+				this.title);
+	}
+
+	@NonNull
+	@Override
+	public ShaderProjectOrigin getOrigin() {
+		return origin;
+	}
+
+	@NonNull
+	@Override
+	public ShaderProjectSession openSession() {
+		ShaderProject project = new ShaderProject(
+				origin,
+				title,
+				entryFilePath,
+				files);
+		return new ShaderProjectSession(project, project.getEntryFilePath(), quality);
+	}
+
+	@NonNull
+	private static String getTitle(@Nullable Uri rootUri, @Nullable String title) {
+		if (title != null && !title.trim().isEmpty()) {
+			return title.trim();
+		}
+		String fallback = null;
+		if (rootUri != null) {
+			fallback = rootUri.getLastPathSegment();
+			if (fallback != null) {
+				int slash = fallback.lastIndexOf('/');
+				if (slash >= 0 && slash + 1 < fallback.length()) {
+					fallback = fallback.substring(slash + 1);
+				}
+				int colon = fallback.lastIndexOf(':');
+				if (colon >= 0 && colon + 1 < fallback.length()) {
+					fallback = fallback.substring(colon + 1);
+				}
+				fallback = fallback.trim();
+			}
+		}
+		return fallback == null || fallback.isEmpty() ? "Project" : fallback;
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/project/LegacyShaderProjectSource.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/project/LegacyShaderProjectSource.java
@@ -1,0 +1,57 @@
+package de.markusfisch.android.shadereditor.project;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+import java.util.Objects;
+
+import de.markusfisch.android.shadereditor.database.DataRecords;
+
+public final class LegacyShaderProjectSource implements ShaderProjectSource {
+	@NonNull
+	private final DataRecords.Shader shader;
+	@NonNull
+	private final ShaderProjectOrigin origin;
+	@NonNull
+	private final String title;
+
+	public LegacyShaderProjectSource(@NonNull DataRecords.Shader shader) {
+		this.shader = Objects.requireNonNull(shader);
+		title = getTitle(shader);
+		origin = new ShaderProjectOrigin(
+				ShaderProjectOrigin.Type.LEGACY_DB,
+				"shader:" + shader.id(),
+				title);
+	}
+
+	@NonNull
+	@Override
+	public ShaderProjectOrigin getOrigin() {
+		return origin;
+	}
+
+	@NonNull
+	@Override
+	public ShaderProjectSession openSession() {
+		ShaderProject project = new ShaderProject(
+				origin,
+				title,
+				ShaderProjectPaths.DEFAULT_ENTRY_FILE,
+				List.of(new ShaderProjectFile(
+						ShaderProjectPaths.DEFAULT_ENTRY_FILE,
+						shader.fragmentShader())));
+		return new ShaderProjectSession(
+				project,
+				project.getEntryFilePath(),
+				shader.quality());
+	}
+
+	@NonNull
+	private static String getTitle(@NonNull DataRecords.Shader shader) {
+		String title = shader.getTitle();
+		if (title == null || title.trim().isEmpty()) {
+			return "Shader " + shader.id();
+		}
+		return title;
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/project/LooseShaderFileProjectSource.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/project/LooseShaderFileProjectSource.java
@@ -1,0 +1,88 @@
+package de.markusfisch.android.shadereditor.project;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class LooseShaderFileProjectSource implements ShaderProjectSource {
+	@NonNull
+	private final String filePath;
+	@NonNull
+	private final String source;
+	private final float quality;
+	@NonNull
+	private final ShaderProjectOrigin origin;
+	@NonNull
+	private final String title;
+
+	public LooseShaderFileProjectSource(@Nullable Uri fileUri,
+			@NonNull String source,
+			float quality) {
+		this(fileUri, getDefaultFilePath(fileUri), source, quality);
+	}
+
+	public LooseShaderFileProjectSource(@Nullable Uri fileUri,
+			@NonNull String filePath,
+			@NonNull String source,
+			float quality) {
+		this.filePath = ShaderProjectPaths.normalize(filePath);
+		this.source = Objects.requireNonNull(source);
+		this.quality = quality;
+		title = getDisplayName(fileUri, this.filePath);
+		origin = new ShaderProjectOrigin(
+				ShaderProjectOrigin.Type.LOOSE_FILE,
+				fileUri != null ? fileUri.toString() : "scratch:" + this.filePath,
+				title);
+	}
+
+	@NonNull
+	@Override
+	public ShaderProjectOrigin getOrigin() {
+		return origin;
+	}
+
+	@NonNull
+	@Override
+	public ShaderProjectSession openSession() {
+		ShaderProject project = new ShaderProject(
+				origin,
+				title,
+				filePath,
+				List.of(new ShaderProjectFile(filePath, source)));
+		return new ShaderProjectSession(project, project.getEntryFilePath(), quality);
+	}
+
+	@NonNull
+	private static String getDefaultFilePath(@Nullable Uri fileUri) {
+		String displayName = getDisplayName(fileUri,
+				ShaderProjectPaths.DEFAULT_ENTRY_FILE);
+		return displayName.isEmpty()
+				? ShaderProjectPaths.DEFAULT_ENTRY_FILE
+				: displayName;
+	}
+
+	@NonNull
+	private static String getDisplayName(@Nullable Uri fileUri,
+			@NonNull String fallback) {
+		String name = null;
+		if (fileUri != null) {
+			name = fileUri.getLastPathSegment();
+			if (name != null) {
+				int slash = name.lastIndexOf('/');
+				if (slash >= 0 && slash + 1 < name.length()) {
+					name = name.substring(slash + 1);
+				}
+				int colon = name.lastIndexOf(':');
+				if (colon >= 0 && colon + 1 < name.length()) {
+					name = name.substring(colon + 1);
+				}
+				name = name.trim();
+			}
+		}
+		return name == null || name.isEmpty() ? fallback : name;
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProject.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProject.java
@@ -1,0 +1,121 @@
+package de.markusfisch.android.shadereditor.project;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class ShaderProject implements Serializable {
+	@NonNull
+	private final ShaderProjectOrigin origin;
+	@NonNull
+	private final String title;
+	@NonNull
+	private final String entryFilePath;
+	@NonNull
+	private final List<ShaderProjectFile> files;
+	@NonNull
+	private final Map<String, ShaderProjectFile> filesByPath;
+
+	public ShaderProject(@NonNull ShaderProjectOrigin origin,
+			@NonNull String title,
+			@NonNull String entryFilePath,
+			@NonNull List<ShaderProjectFile> files) {
+		this.origin = Objects.requireNonNull(origin);
+		this.title = requireText(title, "title");
+		this.entryFilePath = ShaderProjectPaths.normalize(entryFilePath);
+
+		ArrayList<ShaderProjectFile> orderedFiles = new ArrayList<>(
+				Objects.requireNonNull(files).size());
+		LinkedHashMap<String, ShaderProjectFile> indexedFiles = new LinkedHashMap<>();
+		for (ShaderProjectFile file : files) {
+			ShaderProjectFile projectFile = Objects.requireNonNull(file);
+			if (indexedFiles.put(projectFile.path(), projectFile) != null) {
+				throw new IllegalArgumentException(
+						"Duplicate project file: " + projectFile.path());
+			}
+			orderedFiles.add(projectFile);
+		}
+
+		if (!indexedFiles.containsKey(this.entryFilePath)) {
+			throw new IllegalArgumentException(
+					"Missing entry file: " + this.entryFilePath);
+		}
+
+		this.files = Collections.unmodifiableList(orderedFiles);
+		this.filesByPath = Collections.unmodifiableMap(indexedFiles);
+	}
+
+	@NonNull
+	public ShaderProjectOrigin getOrigin() {
+		return origin;
+	}
+
+	@NonNull
+	public String getTitle() {
+		return title;
+	}
+
+	@NonNull
+	public String getEntryFilePath() {
+		return entryFilePath;
+	}
+
+	@NonNull
+	public List<ShaderProjectFile> getFiles() {
+		return files;
+	}
+
+	@Nullable
+	public ShaderProjectFile getFile(@NonNull String path) {
+		return filesByPath.get(ShaderProjectPaths.normalize(path));
+	}
+
+	public boolean hasFile(@NonNull String path) {
+		return getFile(path) != null;
+	}
+
+	@NonNull
+	public ShaderProjectFile requireFile(@NonNull String path) {
+		ShaderProjectFile file = getFile(path);
+		if (file == null) {
+			throw new IllegalArgumentException(
+					"Unknown project file: " + ShaderProjectPaths.normalize(path));
+		}
+		return file;
+	}
+
+	@NonNull
+	public ShaderProjectFile getEntryFile() {
+		return requireFile(entryFilePath);
+	}
+
+	@NonNull
+	public ShaderProject withFileSource(@NonNull String path, @NonNull String source) {
+		String normalizedPath = ShaderProjectPaths.normalize(path);
+		requireFile(normalizedPath);
+
+		ArrayList<ShaderProjectFile> updatedFiles = new ArrayList<>(files.size());
+		for (ShaderProjectFile file : files) {
+			updatedFiles.add(file.path().equals(normalizedPath)
+					? file.withSource(source)
+					: file);
+		}
+		return new ShaderProject(origin, title, entryFilePath, updatedFiles);
+	}
+
+	@NonNull
+	private static String requireText(String value, String name) {
+		String text = Objects.requireNonNull(value, name).trim();
+		if (text.isEmpty()) {
+			throw new IllegalArgumentException(name + " must not be empty");
+		}
+		return text;
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectFile.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectFile.java
@@ -1,0 +1,26 @@
+package de.markusfisch.android.shadereditor.project;
+
+import androidx.annotation.NonNull;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public record ShaderProjectFile(
+		@NonNull String path,
+		@NonNull String source
+) implements Serializable {
+	public ShaderProjectFile {
+		path = ShaderProjectPaths.normalize(path);
+		source = Objects.requireNonNull(source);
+	}
+
+	@NonNull
+	public String getName() {
+		return ShaderProjectPaths.getFileName(path);
+	}
+
+	@NonNull
+	public ShaderProjectFile withSource(@NonNull String source) {
+		return new ShaderProjectFile(path, source);
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectOrigin.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectOrigin.java
@@ -1,0 +1,33 @@
+package de.markusfisch.android.shadereditor.project;
+
+import androidx.annotation.NonNull;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public record ShaderProjectOrigin(
+		@NonNull Type type,
+		@NonNull String id,
+		@NonNull String displayName
+) implements Serializable {
+	public enum Type {
+		FOLDER,
+		LOOSE_FILE,
+		LEGACY_DB
+	}
+
+	public ShaderProjectOrigin {
+		type = Objects.requireNonNull(type);
+		id = requireText(id, "id");
+		displayName = requireText(displayName, "displayName");
+	}
+
+	@NonNull
+	private static String requireText(String value, String name) {
+		String text = Objects.requireNonNull(value, name).trim();
+		if (text.isEmpty()) {
+			throw new IllegalArgumentException(name + " must not be empty");
+		}
+		return text;
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectPaths.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectPaths.java
@@ -1,0 +1,63 @@
+package de.markusfisch.android.shadereditor.project;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.Objects;
+
+public final class ShaderProjectPaths {
+	public static final String DEFAULT_ENTRY_FILE = "main.glsl";
+
+	private ShaderProjectPaths() {
+	}
+
+	@NonNull
+	public static String normalize(@NonNull String path) {
+		String normalized = Objects.requireNonNull(path)
+				.replace('\\', '/')
+				.trim();
+
+		if (normalized.isEmpty()) {
+			throw new IllegalArgumentException("Path must not be empty");
+		}
+
+		String[] parts = normalized.split("/+");
+		ArrayDeque<String> segments = new ArrayDeque<>(parts.length);
+		for (String part : parts) {
+			if (part == null || part.isEmpty() || ".".equals(part)) {
+				continue;
+			}
+			if ("..".equals(part)) {
+				if (segments.isEmpty()) {
+					throw new IllegalArgumentException(
+							"Path escapes project root: " + path);
+				}
+				segments.removeLast();
+				continue;
+			}
+			segments.addLast(part);
+		}
+
+		if (segments.isEmpty()) {
+			throw new IllegalArgumentException("Path must not be empty: " + path);
+		}
+
+		StringBuilder builder = new StringBuilder();
+		Iterator<String> iterator = segments.iterator();
+		while (iterator.hasNext()) {
+			builder.append(iterator.next());
+			if (iterator.hasNext()) {
+				builder.append('/');
+			}
+		}
+		return builder.toString();
+	}
+
+	@NonNull
+	public static String getFileName(@NonNull String path) {
+		String normalized = normalize(path);
+		int slash = normalized.lastIndexOf('/');
+		return slash >= 0 ? normalized.substring(slash + 1) : normalized;
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectSession.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectSession.java
@@ -1,0 +1,82 @@
+package de.markusfisch.android.shadereditor.project;
+
+import androidx.annotation.NonNull;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public final class ShaderProjectSession implements Serializable {
+	@NonNull
+	private final ShaderProject project;
+	@NonNull
+	private final String activeFilePath;
+	private final float quality;
+
+	public ShaderProjectSession(@NonNull ShaderProject project,
+			@NonNull String activeFilePath,
+			float quality) {
+		this.project = Objects.requireNonNull(project);
+		this.activeFilePath = ShaderProjectPaths.normalize(activeFilePath);
+		this.project.requireFile(this.activeFilePath);
+		this.quality = quality;
+	}
+
+	@NonNull
+	public ShaderProject getProject() {
+		return project;
+	}
+
+	@NonNull
+	public String getActiveFilePath() {
+		return activeFilePath;
+	}
+
+	@NonNull
+	public ShaderProjectFile getActiveFile() {
+		return project.requireFile(activeFilePath);
+	}
+
+	@NonNull
+	public ShaderProjectFile getEntryFile() {
+		return project.getEntryFile();
+	}
+
+	@NonNull
+	public String getEntryPointSource() {
+		return getEntryFile().source();
+	}
+
+	public float getQuality() {
+		return quality;
+	}
+
+	@NonNull
+	public ShaderProjectSession withActiveFile(@NonNull String path) {
+		return new ShaderProjectSession(project, path, quality);
+	}
+
+	@NonNull
+	public ShaderProjectSession withQuality(float quality) {
+		return new ShaderProjectSession(project, activeFilePath, quality);
+	}
+
+	@NonNull
+	public ShaderProjectSession withEntryPointSource(@NonNull String source) {
+		return new ShaderProjectSession(
+				project.withFileSource(project.getEntryFilePath(), source),
+				activeFilePath,
+				quality);
+	}
+
+	@NonNull
+	public ShaderProjectSession withFileSource(@NonNull String path,
+			@NonNull String source) {
+		String normalizedPath = ShaderProjectPaths.normalize(path);
+		return new ShaderProjectSession(
+				project.withFileSource(normalizedPath, source),
+				activeFilePath.equals(normalizedPath)
+						? normalizedPath
+						: activeFilePath,
+				quality);
+	}
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectSource.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/project/ShaderProjectSource.java
@@ -1,0 +1,11 @@
+package de.markusfisch.android.shadereditor.project;
+
+import androidx.annotation.NonNull;
+
+public interface ShaderProjectSource {
+	@NonNull
+	ShaderProjectOrigin getOrigin();
+
+	@NonNull
+	ShaderProjectSession openSession();
+}

--- a/app/src/main/java/de/markusfisch/android/shadereditor/service/ShaderWallpaperService.java
+++ b/app/src/main/java/de/markusfisch/android/shadereditor/service/ShaderWallpaperService.java
@@ -8,11 +8,15 @@ import android.service.wallpaper.WallpaperService;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 
+import androidx.annotation.Nullable;
+
 import de.markusfisch.android.shadereditor.app.ShaderEditorApp;
 import de.markusfisch.android.shadereditor.database.DataRecords;
 import de.markusfisch.android.shadereditor.database.DataSource;
 import de.markusfisch.android.shadereditor.database.Database;
 import de.markusfisch.android.shadereditor.preference.Preferences;
+import de.markusfisch.android.shadereditor.project.LegacyShaderProjectSource;
+import de.markusfisch.android.shadereditor.project.ShaderProjectSession;
 import de.markusfisch.android.shadereditor.receiver.BatteryLevelReceiver;
 import de.markusfisch.android.shadereditor.widget.ShaderView;
 
@@ -133,6 +137,16 @@ public class ShaderWallpaperService extends WallpaperService {
 		}
 
 		private void setShader() {
+			ShaderProjectSession projectSession = openWallpaperProjectSession();
+			if (view != null && projectSession != null) {
+				view.getRenderer().setFragmentShader(
+						projectSession.getEntryPointSource(),
+						projectSession.getQuality());
+			}
+		}
+
+		@Nullable
+		private ShaderProjectSession openWallpaperProjectSession() {
 			DataSource dataSource = Database.getInstance(
 					ShaderWallpaperService.this).getDataSource();
 
@@ -145,18 +159,14 @@ public class ShaderWallpaperService extends WallpaperService {
 
 				// If there are no shaders at all, we can't do anything.
 				if (shader == null) {
-					return;
+					return null;
 				}
 
 				// Update the preferences to store the new random shader ID.
 				ShaderEditorApp.preferences.setWallpaperShader(shader.id());
 			}
 
-			if (view != null) {
-				view.getRenderer().setFragmentShader(
-						shader.fragmentShader(),
-						shader.quality());
-			}
+			return new LegacyShaderProjectSource(shader).openSession();
 		}
 
 		private class ShaderWallpaperView extends ShaderView {


### PR DESCRIPTION
## Summary

Introduce a canonical project/session model for shader loading so the main editor preview, fullscreen preview, and wallpaper runtime can work from one project abstraction instead of raw fragment-shader strings. This lays the groundwork for folder-based project mode _(see #191)_ while keeping legacy database shaders and loose-file imports compatible.

## Changes

- add a new `project/` package with canonical project, file, origin, path, and session models plus source adapters for legacy DB shaders, loose files, and folder-backed projects
- refactor `ShaderManager` to load selected shaders and imported files as `ShaderProjectSession` instances and keep renderer state derived from the active session
- update preview navigation, `PreviewActivity`, `ShaderViewManager`, and `ShaderWallpaperService` to accept project sessions instead of only raw fragment shader text
